### PR TITLE
Add a new "started_at" column to BigQuery table

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -170,7 +170,7 @@ def _single_run(bazel_binary_path,
             ['--nostamp', '--noshow_progress', '--color=no']))
     options = default_options + options
 
-  times = bazel.command(
+  measurements = bazel.command(
       command_name=command,
       args=options + expressions,
       collect_memory=collect_memory)
@@ -178,7 +178,7 @@ def _single_run(bazel_binary_path,
   # Get back to a clean state.
   bazel.command('clean', ['--color=no'])
   bazel.command('shutdown')
-  return times
+  return measurements
 
 
 def _run_benchmark(bazel_binary_path,

--- a/benchmark.py
+++ b/benchmark.py
@@ -154,6 +154,8 @@ def _single_run(bazel_binary_path,
       'cpu': 1.000,
       'system': 1.000,
       'memory': 1.000,
+      'exit_status': 0,
+      'started_at': datetime.datetime(2019, 1, 1, 0, 0, 0, 000000),
     }
   """
   bazel = Bazel(bazel_binary_path, bazelrc)
@@ -358,7 +360,7 @@ def main(argv):
     print('Bazel commit: %s, Project commit: %s, Project source: %s' %
           (bazel_commit, project_commit, FLAGS.project_source))
     for metric, values in sorted(collected.items()):
-      if metric == 'exit_status':
+      if metric in ['exit_status', 'started_at']:
         continue
       if last_collected:
         base = last_collected[metric]

--- a/utils/bazel.py
+++ b/utils/bazel.py
@@ -59,7 +59,6 @@ class Bazel(object):
         'Executing Bazel command: bazel %s %s' % (command_name, ' '.join(args)))
 
     result = dict()
-    # Use UTC.
     result['started_at'] = datetime.datetime.utcnow()
 
     before_times = self._get_times()

--- a/utils/bazel.py
+++ b/utils/bazel.py
@@ -17,6 +17,7 @@ import os
 import time
 import psutil
 import logger
+import datetime
 
 
 class Bazel(object):
@@ -49,12 +50,17 @@ class Bazel(object):
 
     Returns:
       A dict containing collected metrics (wall, cpu, system times and
-      optionally memory) and the exit_status of the Blaze invocation.
+      optionally memory), the exit_status of the Bazel invocation, and the
+      start datetime (in UTC).
       Returns None instead if the command equals 'shutdown'.
     """
     args = args or []
     logger.log(
         'Executing Bazel command: bazel %s %s' % (command_name, ' '.join(args)))
+
+    result = dict()
+    # Use UTC.
+    result['started_at'] = datetime.datetime.utcnow()
 
     before_times = self._get_times()
     dev_null = open(os.devnull, 'w')
@@ -67,7 +73,6 @@ class Bazel(object):
       return None
     after_times = self._get_times()
 
-    result = dict()
     for kind in ['wall', 'cpu', 'system']:
       result[kind] = after_times[kind] - before_times[kind]
     result['exit_status'] = exit_status

--- a/utils/output_handling.py
+++ b/utils/output_handling.py
@@ -46,7 +46,7 @@ def export_csv(data_directory, data, project_source):
     csv_writer.writerow([
         'project_source', 'project_commit', 'bazel_commit', 'run', 'cpu',
         'wall', 'system', 'memory', 'command', 'expressions', 'hostname',
-        'username', 'options', 'exit_status'
+        'username', 'options', 'exit_status', 'started_at'
     ])
 
     for (bazel_commit, project_commit), results_and_args in sorted(data.items()):
@@ -55,7 +55,8 @@ def export_csv(data_directory, data, project_source):
         csv_writer.writerow([
             project_source, project_commit, bazel_commit, idx, run['cpu'],
             run['wall'], run['system'], run['memory'], command, expressions,
-            hostname, username, options, run['exit_status']
+            hostname, username, options, run['exit_status'],
+            run['started_at']
         ])
   return csv_file_path
 


### PR DESCRIPTION
Changes:

- Add a new "started_at" column to the csv output
- [Non-code] Created the column on BigQuery

Note: according to [`google-cloud-python`](https://github.com/googleapis/google-cloud-python/blob/11e310ab9f63f06252ff2b9ada201fd8c11ce06c/bigquery/google/cloud/bigquery/dbapi/types.py#L28), Python `datetime.datetime` type is mapped to `TIMESTAMP` type on BigQuery.

I've also created the column on BigQuery and verified that uploading works.