### PR TITLE
Replace raw git bash commands with Gitpython

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -59,7 +59,8 @@ def _exec_command(args, shell=False, fail_if_nonzero=True):
 def _get_commits(commits_list, repo, flag_name):
   """Returns a list of commits.
 
-  If the input commits_list is empty, fetch the latest commit from repo.
+  If the input commits_list is empty, fetch the latest commit on branch 'master'
+  of the repo.
 
   Args:
     commits_list: a list of string of commit SHA digest.

--- a/benchmark_test.py
+++ b/benchmark_test.py
@@ -20,7 +20,6 @@ import mock
 import sys
 import benchmark
 import six
-import git
 
 from absl.testing import absltest
 from absl.testing import flagsaver

--- a/benchmark_test.py
+++ b/benchmark_test.py
@@ -55,10 +55,10 @@ class BenchmarkFunctionTests(absltest.TestCase):
                                          unused_exists_mock):
     with mock.patch.object(sys, 'stderr', new=mock_stdio_type()) as mock_stderr, \
       mock.patch('benchmark.git.Repo') as mock_repo_class:
-        mock_repo = mock_repo_class.return_value
         benchmark._setup_project_repo('repo_path', 'project_source')
 
-
+    mock_repo_class.clone_from.assert_called_once_with('project_source',
+                                                       'repo_path')
     self.assertEqual("Cloning project_source to repo_path...",
                      mock_stderr.getvalue())
 

--- a/benchmark_test.py
+++ b/benchmark_test.py
@@ -58,19 +58,6 @@ class BenchmarkFunctionTests(absltest.TestCase):
         "['git', 'clone', 'project_source', 'repo_path']"]),
         mock_stderr.getvalue())
 
-  @mock.patch.object(benchmark.os, 'chdir')
-  def test_checkout_project_commit_latest(self, _):
-    with mock.patch.object(sys, 'stderr', new=mock_stdio_type()) as mock_stderr:
-      benchmark._checkout_project_commit('latest', 'project_path')
-    self.assertTrue(len(mock_stderr.getvalue()) == 0)
-
-  @mock.patch.object(benchmark.os, 'chdir')
-  def test_checkout_project_commit_hash(self, _):
-    with mock.patch.object(sys, 'stderr', new=mock_stdio_type()) as mock_stderr:
-      benchmark._checkout_project_commit('some_hash', 'project_path')
-    self.assertEqual("['git', 'checkout', '-f', 'some_hash']",
-                     mock_stderr.getvalue())
-
   @mock.patch.object(benchmark.os.path, 'exists', return_value=True)
   @mock.patch.object(benchmark.os, 'makedirs')
   def test_build_bazel_binary_exists(self, unused_chdir_mock,

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ chardet==3.0.4
 enum34==1.1.6
 funcsigs==1.0.2
 futures==3.2.0
+GitPython==2.1.11
 google-api-core==1.8.0
 google-auth==1.6.3
 google-cloud-bigquery==1.9.0


### PR DESCRIPTION
**Why?**
We've been calling "raw" `git` commands with `subprocess`. This has a few disadvantages:
- ~Requires the internal navigation to various directories with `os.chdir`. This is prone to obscure bugs  e.g. if one forgets to change back to the correct directory.~
- Extracting the latest commit of a repository is troublesome.
We have been using the string "latest" to represent this. It's fine in the context of running the script in the command line and immediately consume the result, but on BigQuery it's wrong since "latest" at different points in time mean different commits.

GitPython addresses these issues.

**Changes:**

- Use GitPython to perform git interactions now.
- Replacing "latest" by getting the actual latest commit's SHA.