### PR TITLE
Fix default outpath

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -48,7 +48,7 @@ BAZEL_GITHUB_URL = 'https://github.com/bazelbuild/bazel.git'
 # The path to the directory that stores the bazel binaries.
 BAZEL_BINARY_BASE_PATH = _platform_path_str('%s/.bazel-bench/bazel-bin/' % TMP)
 # The path to the directory that stores the output csv (If required).
-DEFAULT_OUT_BASE_PATH = _platform_path_str('%s/tmp/.bazel-bench/out/' % TMP)
+DEFAULT_OUT_BASE_PATH = _platform_path_str('%s/.bazel-bench/out/' % TMP)
 
 
 def _get_clone_subdir(project_source):


### PR DESCRIPTION
**What this PR does and why we need it:**

Fix the default tmp path for output csv. Previously the path would look something like `/tmp/tmp/.bazel-bench/out` on Linux.

**New changes / Issues that this PR fixes:**

The fixed default tmp path is `/tmp/.bazel-bench/out`

**Special notes for reviewer:**

None

**Does this require a change in the script's interface or the BigQuery's table structure?**

None
