### PR TITLE
Add 2 commit times columns in csv & BigQuery

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -86,10 +86,10 @@ def _get_commits(commits_sha_list, repo, flag_name):
     return [repo.commit(sha) for sha in commits_sha_list]
 
   # If no commit specified: take the repo's latest commit.
-  latest_commit_sha = repo.commit().hexsha
+  latest_commit = repo.commit()
   logger.log(
-      'No %s specified, using the latest one: %s' % (flag_name, latest_commit_sha))
-  return [repo.commit(latest_commit_sha)]
+      'No %s specified, using the latest one: %s' % (flag_name, latest_commit.hexsha))
+  return [latest_commit]
 
 
 def _setup_project_repo(repo_path, project_source):

--- a/utils/output_handling.py
+++ b/utils/output_handling.py
@@ -44,19 +44,22 @@ def export_csv(data_directory, data, project_source):
     username = getpass.getuser()
     csv_writer = csv.writer(csv_file)
     csv_writer.writerow([
-        'project_source', 'project_commit', 'bazel_commit', 'run', 'cpu',
-        'wall', 'system', 'memory', 'command', 'expressions', 'hostname',
-        'username', 'options', 'exit_status', 'started_at'
+        'project_source', 'project_commit', 'project_commit_time',
+        'bazel_commit', 'bazel_commit_time', 'run', 'cpu', 'wall', 'system',
+        'memory', 'command', 'expressions', 'hostname', 'username', 'options',
+        'exit_status', 'started_at'
     ])
 
-    for (bazel_commit, project_commit), results_and_args in sorted(data.items()):
-      command, expressions, options = results_and_args['args']
-      for idx, run in enumerate(results_and_args['results'], start=1):
+    for (bazel_commit, project_commit), data_item in sorted(data.items()):
+      command, expressions, options = data_item['args']
+      bazel_commit_time = data_item['bazel_commit_time']
+      project_commit_time = data_item['project_commit_time']
+      for idx, run in enumerate(data_item['results'], start=1):
         csv_writer.writerow([
-            project_source, project_commit, bazel_commit, idx, run['cpu'],
-            run['wall'], run['system'], run['memory'], command, expressions,
-            hostname, username, options, run['exit_status'],
-            run['started_at']
+            project_source, project_commit, project_commit_time, bazel_commit,
+            bazel_commit_time, idx, run['cpu'], run['wall'], run['system'],
+            run['memory'], command, expressions, hostname, username, options,
+            run['exit_status'], run['started_at']
         ])
   return csv_file_path
 


### PR DESCRIPTION
**What this PR does and why we need it:**

For git commits, we can't work out the chronological order from the commit ID. Getting the order is important for displaying the data on a graph. To determine this order, we'll fetch the datetime at which the commit was created.

**New changes / Issues that this PR fixes:**

- Add 2 new columns in the csv output: `project_commit_time` and `bazel_commit_time`.

**Special notes for reviewer:**

Since this is required for data collection, I'll go ahead and update the BigQuery table first. We can make amends if necessary.

**Does this require a change in the script's interface or the BigQuery's table structure?**

This requires the addition of 2 new columns on BigQuery: `project_commit_time` and `bazel_commit_time`.

- [ ] BigQuery updated.
