### PR TITLE
Topological commit ordering

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -86,8 +86,7 @@ def _get_commits_topological(commits_sha_list, repo, flag_name):
   """
   if commits_sha_list:
     commits_sha_set = set(commits_sha_list)
-    return list(
-        reversed([c.hexsha for c in repo.iter_commits if c.hexsha in commits_sha_set]))
+    return [c.hexsha for c in reversed(list(repo.iter_commits())) if c.hexsha in commits_sha_set]
 
   # If no commit specified: take the repo's latest commit.
   latest_commit_sha = repo.commit().hexsha

--- a/benchmark.py
+++ b/benchmark.py
@@ -82,7 +82,7 @@ def _get_commits_topological(commits_sha_list, repo, flag_name):
     flag_name: the flag that is supposed to specify commits_list.
 
   Returns:
-    A list of string of commit SHA digests, sorted by commit topological order.
+    A list of string of commit SHA digests, sorted by topological commit order.
   """
   if commits_sha_list:
     commits_sha_set = set(commits_sha_list)

--- a/benchmark_test.py
+++ b/benchmark_test.py
@@ -62,6 +62,22 @@ class BenchmarkFunctionTests(absltest.TestCase):
     self.assertEqual("Cloning project_source to repo_path...",
                      mock_stderr.getvalue())
 
+  def test_get_commits_topological(self):
+    with mock.patch.object(sys, 'stderr', new=mock_stdio_type()) as mock_stderr, \
+      mock.patch('benchmark.git.Repo') as mock_repo_class, \
+      mock.patch('benchmark.git.Commit') as mock_commit_class:
+        mock_repo = mock_repo_class.return_value
+        mock_A = mock_commit_class.return_value
+        mock_A.hexsha = 'A'
+        mock_B = mock_commit_class.return_value
+        mock_B.hexsha = 'B'
+        mock_C = mock_commit_class.return_value
+        mock_C.hexsha = 'C'
+        mock_repo.iter_commits = [mock_A, mock_B, mock_C]
+        result = benchmark._get_commits_topological(
+            ['B', 'A'], mock_repo, 'flag_name')
+
+        self.assertEqual(['A', 'B'], result)
   @mock.patch.object(benchmark.os.path, 'exists', return_value=True)
   @mock.patch.object(benchmark.os, 'makedirs')
   def test_build_bazel_binary_exists(self, unused_chdir_mock,

--- a/benchmark_test.py
+++ b/benchmark_test.py
@@ -63,21 +63,34 @@ class BenchmarkFunctionTests(absltest.TestCase):
                      mock_stderr.getvalue())
 
   def test_get_commits_topological(self):
-    with mock.patch.object(sys, 'stderr', new=mock_stdio_type()) as mock_stderr, \
-      mock.patch('benchmark.git.Repo') as mock_repo_class, \
-      mock.patch('benchmark.git.Commit') as mock_commit_class:
+    with mock.patch('benchmark.git.Repo') as mock_repo_class:
         mock_repo = mock_repo_class.return_value
-        mock_A = mock_commit_class.return_value
+        mock_A = mock.MagicMock()
         mock_A.hexsha = 'A'
-        mock_B = mock_commit_class.return_value
+        mock_B = mock.MagicMock()
         mock_B.hexsha = 'B'
-        mock_C = mock_commit_class.return_value
+        mock_C = mock.MagicMock()
         mock_C.hexsha = 'C'
-        mock_repo.iter_commits = [mock_A, mock_B, mock_C]
+        mock_repo.iter_commits = [mock_C, mock_B, mock_A]
         result = benchmark._get_commits_topological(
             ['B', 'A'], mock_repo, 'flag_name')
 
         self.assertEqual(['A', 'B'], result)
+
+  def test_get_commits_topological_latest(self):
+    with mock.patch.object(sys, 'stderr', new=mock_stdio_type()) as mock_stderr, \
+      mock.patch('benchmark.git.Repo') as mock_repo_class:
+        mock_repo = mock_repo_class.return_value
+        mock_commit = mock.MagicMock()
+        mock_repo.commit.return_value = mock_commit
+        mock_commit.hexsha = 'A'
+        result = benchmark._get_commits_topological(None, mock_repo, 'bazel_commits')
+
+    self.assertEqual(['A'], result)
+    self.assertEqual('No bazel_commits specified, using the latest one: A',
+                     mock_stderr.getvalue())
+
+
   @mock.patch.object(benchmark.os.path, 'exists', return_value=True)
   @mock.patch.object(benchmark.os, 'makedirs')
   def test_build_bazel_binary_exists(self, unused_chdir_mock,


### PR DESCRIPTION
**What this PR does and why we need it:**

For git commits, we can't work out the topological order from the commit ID. Getting the order is important for displaying the data on a graph. To determine this order, we'll fetch the commit history from the repository and order the input commit (topological order) based on that.

**New changes / Issues that this PR fixes:**

- Sort input commits by topological order.

**Special notes for reviewer:**

None

**Does this require a change in the script's interface or the BigQuery's table structure?**

No
