### PR TITLE
Rm sorting of commit hashes in output

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -398,10 +398,10 @@ def main(argv):
 
   print('\nRESULTS:')
   last_collected = None
-  for (bazel_commit, project_commit), collected in sorted(data.items()):
+  for (bazel_commit, project_commit), collected in data.items():
     print('Bazel commit: %s, Project commit: %s, Project source: %s' %
           (bazel_commit, project_commit, FLAGS.project_source))
-    for metric, values in sorted(collected.items()):
+    for metric, values in collected.items():
       if metric in ['exit_status', 'started_at']:
         continue
       if last_collected:

--- a/utils/output_handling.py
+++ b/utils/output_handling.py
@@ -49,7 +49,7 @@ def export_csv(data_directory, data, project_source):
         'username', 'options', 'exit_status', 'started_at'
     ])
 
-    for (bazel_commit, project_commit), results_and_args in sorted(data.items()):
+    for (bazel_commit, project_commit), results_and_args in data.items():
       command, expressions, options = results_and_args['args']
       for idx, run in enumerate(results_and_args['results'], start=1):
         csv_writer.writerow([


### PR DESCRIPTION
**What this PR does and why we need it:**

This PR removes the unnecessary `sorted` function application to the collected data. It makes no sense to sort git commit hashes.

**New changes / Issues that this PR fixes:**

* Remove sorting of commit hashes when printing result to the cmdline and in the CSV output.

**Special notes for reviewer:**

None

**Does this require a change in the script's interface or the BigQuery's table structure?**

No
