### PR TITLE
Add cwd to _exec_command

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -56,15 +56,14 @@ def _get_clone_subdir(project_source):
   return hashlib.md5(project_source).hexdigest()
 
 
-def _exec_command(args, shell=False, fail_if_nonzero=True):
+def _exec_command(args, shell=False, fail_if_nonzero=True, cwd=None):
   logger.log('Executing: %s' % ' '.join(args))
-
   if FLAGS.verbose:
-    return subprocess.call(args, shell=shell)
+    return subprocess.call(args, shell=shell, cwd=cwd)
 
   fd_devnull = open(os.devnull, 'w')
   return subprocess.call(
-      args, shell=shell, stdout=fd_devnull, stderr=fd_devnull)
+      args, shell=shell, stdout=fd_devnull, stderr=fd_devnull, cwd=cwd)
 
 
 def _get_commits_topological(commits_sha_list, repo, flag_name):
@@ -145,7 +144,7 @@ def _build_bazel_binary(commit, repo, outroot):
   logger.log('Building Bazel binary at commit %s' % commit)
   repo.git.checkout('-f', commit)
 
-  _exec_command(['bazel', 'build', '//src:bazel'])
+  _exec_command(['bazel', 'build', '//src:bazel'], cwd=repo.working_dir)
 
   # Copy to another location
   binary_out = '%s/bazel-bin/src/bazel' % repo.working_dir

--- a/benchmark_test.py
+++ b/benchmark_test.py
@@ -71,7 +71,7 @@ class BenchmarkFunctionTests(absltest.TestCase):
         mock_B.hexsha = 'B'
         mock_C = mock.MagicMock()
         mock_C.hexsha = 'C'
-        mock_repo.iter_commits = [mock_C, mock_B, mock_A]
+        mock_repo.iter_commits.return_value = [mock_C, mock_B, mock_A]
         result = benchmark._get_commits_topological(
             ['B', 'A'], mock_repo, 'flag_name')
 

--- a/testutils/fakes.py
+++ b/testutils/fakes.py
@@ -20,7 +20,7 @@ def fake_log(text):
   sys.stderr.write(text)
 
 
-def fake_exec_command(args, shell=False, fail_if_nonzero=True):
+def fake_exec_command(args, shell=False, fail_if_nonzero=True, cwd=None):
   """Fakes the _exec_command function."""
   fake_log(args)
 


### PR DESCRIPTION
**What this PR does and why we need it:**

This PR adds the ability to execute commands in a specific working directory.

**New changes / Issues that this PR fixes:**

Add the `cwd` parameter in `_exec_command`.

**Special notes for reviewer:**

None

**Does this require a change in the script's interface or the BigQuery's table structure?**

No
