### PR TITLE
Change data_directory requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ run :benchmark \
 -- \
 --bazel_commits=b8468a6b68a405e1a5767894426d3ea9a1a2f22f,ad503849e78b98d762f03168de5a336904280150\
 --project_source=https://github.com/bazelbuild/rules_cc.git \
---data_directory=/tmp/out.csv \
+--data_directory=/tmp/bazel-bench-data \
 -- build //:all
 ```
 
@@ -96,7 +96,7 @@ Some useful flags are:
   --bazelrc: The path to a .bazelrc file.
   --[no]collect_memory: Whether to collect used heap sizes.
     (default: 'false')
-  --data_directory: The directory in which the csv files should be stored (including the trailing "/"). Turns on memory collection.
+  --data_directory: The directory in which the csv files should be stored (excluding the trailing "/"). Turns on memory collection.
   --[no]prefetch_ext_deps: Whether to do an initial run to pre-fetch external dependencies.
     (default: 'true')
   --project_commits: The commits from the git project to be benchmarked.

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Some useful flags are:
   --bazelrc: The path to a .bazelrc file.
   --[no]collect_memory: Whether to collect used heap sizes.
     (default: 'false')
-  --data_directory: The directory in which the csv files should be stored (excluding the trailing "/"). Turns on memory collection.
+  --data_directory: The directory in which the csv files should be stored. Turns on memory collection.
   --[no]prefetch_ext_deps: Whether to do an initial run to pre-fetch external dependencies.
     (default: 'true')
   --project_commits: The commits from the git project to be benchmarked.

--- a/benchmark.py
+++ b/benchmark.py
@@ -242,6 +242,7 @@ def _run_benchmark(bazel_binary_path,
     A list of result objects from each _single_run.
   """
   collected = []
+  os.chdir(project_path)
 
   # Runs the command once to make sure external dependencies are fetched.
   # If prefetch_ext_deps, run the command with --build_event_json_file to get the
@@ -252,7 +253,6 @@ def _run_benchmark(bazel_binary_path,
     if not os.path.exists(bep_json_dir):
       os.makedirs(bep_json_dir)
     bep_json_path = bep_json_dir + 'build_env.json'
-    os.chdir(project_path)
 
     logger.log('Pre-fetching external dependencies & exporting build event json ' \
         'to %s...' % bep_json_path)

--- a/benchmark.py
+++ b/benchmark.py
@@ -242,7 +242,6 @@ def _run_benchmark(bazel_binary_path,
     A list of result objects from each _single_run.
   """
   collected = []
-  os.chdir(project_path)
 
   # Runs the command once to make sure external dependencies are fetched.
   # If prefetch_ext_deps, run the command with --build_event_json_file to get the
@@ -253,6 +252,7 @@ def _run_benchmark(bazel_binary_path,
     if not os.path.exists(bep_json_dir):
       os.makedirs(bep_json_dir)
     bep_json_path = bep_json_dir + 'build_env.json'
+    os.chdir(project_path)
 
     logger.log('Pre-fetching external dependencies & exporting build event json ' \
         'to %s...' % bep_json_path)

--- a/benchmark.py
+++ b/benchmark.py
@@ -317,8 +317,8 @@ flags.DEFINE_boolean('prefetch_ext_deps', True,
 
 # Output storage flags.
 flags.DEFINE_string('data_directory', None,
-                    'The directory in which the csv files should be stored ' \
-                    '(excluding the trailing "/"). Turns on memory collection.')
+                    'The directory in which the csv files should be stored. ' \
+                    'Turns on memory collection.')
 flags.DEFINE_string('upload_data_to', None,
                     'The details of the BigQuery table to upload ' \
                     'results to: <dataset_id>:<table_id>:<location>')

--- a/benchmark.py
+++ b/benchmark.py
@@ -318,7 +318,7 @@ flags.DEFINE_boolean('prefetch_ext_deps', True,
 # Output storage flags.
 flags.DEFINE_string('data_directory', None,
                     'The directory in which the csv files should be stored ' \
-                    '(including the trailing "/"). Turns on memory collection.')
+                    '(excluding the trailing "/"). Turns on memory collection.')
 flags.DEFINE_string('upload_data_to', None,
                     'The details of the BigQuery table to upload ' \
                     'results to: <dataset_id>:<table_id>:<location>')

--- a/utils/output_handling.py
+++ b/utils/output_handling.py
@@ -37,7 +37,7 @@ def export_csv(data_directory, data, project_source):
   """
   if not os.path.exists(data_directory):
     os.makedirs(data_directory)
-  csv_file_path = data_directory + str(uuid.uuid4()) + '.csv'
+  csv_file_path = '%s/%s.csv' % (data_directory, str(uuid.uuid4()))
   logger.log('Writing raw data into csv file: %s' % str(csv_file_path))
 
   with open(csv_file_path, 'w') as csv_file:


### PR DESCRIPTION
**What this PR does and why we need it:**

The `data_directory` requirement to include the trailing slash made the code hard to read if we need to have a subdirectory structure under it. For example:
```
subdir = '%ssubdir' % (FLAGS.data_directory)
```
