### PR TITLE
Allow option to export JSON profile from runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,12 @@ Some useful flags are:
   --upload_data_to: The details of the BigQuery table to upload results to: <dataset_id>:<table_id>:<location>
   --[no]verbose: Whether to include git/Bazel stdout logs.
     (default: 'false')
+  --[no]collect_json_profile: Whether to collect JSON profile for each run.
+    (default: 'false')
 ```
+## Collecting JSON Profile
+
+[Bazel's JSON Profile](https://docs.bazel.build/versions/master/skylark/performance.html#json-profile) is a useful tool to investigate the performance of Bazel. You can configure `bazel-bench` to export these JSON profiles on runs using the `--collect_json_profile` flag.
 
 ## Uploading to BigQuery
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Some useful flags are:
   --[no]verbose: Whether to include git/Bazel stdout logs.
     (default: 'false')
   --[no]collect_json_profile: Whether to collect JSON profile for each run.
+    Requires --data_directory to be set.
     (default: 'false')
 ```
 ## Collecting JSON Profile

--- a/benchmark.py
+++ b/benchmark.py
@@ -361,7 +361,7 @@ flags.DEFINE_boolean('prefetch_ext_deps', True,
                      'Whether to do an initial run to pre-fetch external ' \
                      'dependencies.')
 flags.DEFINE_boolean('collect_json_profile', False,
-                     'Whether to collect JSON profile for each run. Requires' \
+                     'Whether to collect JSON profile for each run. Requires ' \
                      '--data_directory to be set.')
 
 # Output storage flags.

--- a/utils/output_handling.py
+++ b/utils/output_handling.py
@@ -18,16 +18,16 @@ import os
 import csv
 import socket
 import getpass
-import uuid
 
 import logger
 
 
-def export_csv(data_directory, data, project_source):
+def export_csv(data_directory, filename, data, project_source):
   """Exports the content of data to a csv file in data_directory
 
   Args:
     data_directory: the directory to store the csv file.
+    filename: the name of the .csv file.
     data: the collected data to be exported.
     project_source: either a path to the local git project to be built or a
       https url to a GitHub repository.
@@ -37,7 +37,7 @@ def export_csv(data_directory, data, project_source):
   """
   if not os.path.exists(data_directory):
     os.makedirs(data_directory)
-  csv_file_path = '%s/%s.csv' % (data_directory, str(uuid.uuid4()))
+  csv_file_path = '%s/%s.csv' % (data_directory, filename)
   logger.log('Writing raw data into csv file: %s' % str(csv_file_path))
 
   with open(csv_file_path, 'w') as csv_file:


### PR DESCRIPTION
**What this PR does and why we need it:**

This PR adds a new flag `--collect_json_profile` that allows us to collect JSON profiles from the runs, by performing them with [JSON profile flags](https://docs.bazel.build/versions/master/skylark/performance.html#json-profile). 

**New changes / Issues that this PR fixes:**

- Added a new flag & functionality
- Introduced a `bazel_bench_uid`, determined by the start time of the script, to act as a namespace for output files.
Closes: #18 

**Special notes for reviewer:**
None.

**Does this require a change in the script's interface or the BigQuery's table structure?**

No.
