### PR TITLE
Add `platform` column to CSV & BQ output

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -351,6 +351,11 @@ flags.DEFINE_list('project_commits', None,
 # Execution options.
 flags.DEFINE_integer('runs', 3, 'The number of benchmark runs.')
 flags.DEFINE_string('bazelrc', None, 'The path to a .bazelrc file.')
+flags.DEFINE_string('platform',
+                    None,
+                    ('The platform on which bazel-bench is run. This is just '
+                     'to categorize data and has no impact on the actual '
+                     'script execution.'))
 
 # Miscellaneous flags.
 flags.DEFINE_boolean('verbose', False,
@@ -489,7 +494,11 @@ def main(argv):
 
   if FLAGS.data_directory or FLAGS.upload_data_to:
     csv_file_path = export_csv(
-        data_directory, bazel_bench_uid, csv_data, FLAGS.project_source)
+        data_directory,
+        bazel_bench_uid,
+        csv_data,
+        FLAGS.project_source,
+        FLAGS.platform)
     if FLAGS.upload_data_to:
       upload_csv(csv_file_path, FLAGS.upload_data_to)
 

--- a/utils/output_handling.py
+++ b/utils/output_handling.py
@@ -22,7 +22,7 @@ import getpass
 import logger
 
 
-def export_csv(data_directory, filename, data, project_source):
+def export_csv(data_directory, filename, data, project_source, platform):
   """Exports the content of data to a csv file in data_directory
 
   Args:
@@ -31,6 +31,7 @@ def export_csv(data_directory, filename, data, project_source):
     data: the collected data to be exported.
     project_source: either a path to the local git project to be built or a
       https url to a GitHub repository.
+    platform: the platform on which benchmarking was run.
 
   Returns:
     The path to the newly created csv file.
@@ -47,7 +48,7 @@ def export_csv(data_directory, filename, data, project_source):
     csv_writer.writerow([
         'project_source', 'project_commit', 'bazel_commit', 'run', 'cpu',
         'wall', 'system', 'memory', 'command', 'expressions', 'hostname',
-        'username', 'options', 'exit_status', 'started_at'
+        'username', 'options', 'exit_status', 'started_at', 'platform'
     ])
 
     for (bazel_commit, project_commit), results_and_args in data.items():
@@ -56,7 +57,8 @@ def export_csv(data_directory, filename, data, project_source):
         csv_writer.writerow([
             project_source, project_commit, bazel_commit, idx, run['cpu'],
             run['wall'], run['system'], run['memory'], command, expressions,
-            hostname, username, options, run['exit_status'], run['started_at']
+            hostname, username, options, run['exit_status'], run['started_at'],
+            platform
         ])
   return csv_file_path
 


### PR DESCRIPTION
**What this PR does and why we need it:**

This PR adds a new "platform" column to the CSV output. We need it to categorize the data collected with runs on BazelCI by platforms.

**Does this require a change in the script's interface or the BigQuery's table structure?**

Yes.
