### PR TITLE
Add project_id requirement to upload_data_to

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -375,7 +375,7 @@ flags.DEFINE_string('data_directory', None,
                     'Turns on memory collection.')
 flags.DEFINE_string('upload_data_to', None,
                     'The details of the BigQuery table to upload ' \
-                    'results to: <dataset_id>:<table_id>:<location>')
+                    'results to: <project_id>:<dataset_id>:<table_id>:<location>')
 
 
 def _flag_checks():
@@ -387,9 +387,9 @@ def _flag_checks():
     )
 
   if FLAGS.upload_data_to:
-    if not re.match('^[\w-]+:[\w-]+:[\w-]+$', FLAGS.upload_data_to):
+    if not re.match('^[\w-]+:[\w-]+:[\w-]+:[\w-]+$', FLAGS.upload_data_to):
       raise ValueError('--upload_data_to should follow the pattern '
-                       '<dataset_id>:<table_id>:<location>')
+                       '<project_id>:<dataset_id>:<table_id>:<location>')
 
     if ('GOOGLE_APPLICATION_CREDENTIALS' not in os.environ or
         not os.environ['GOOGLE_APPLICATION_CREDENTIALS']):

--- a/benchmark_test.py
+++ b/benchmark_test.py
@@ -265,9 +265,9 @@ class BenchmarkFlagsTest(absltest.TestCase):
     self.assertEqual(
         value_err.message,
         '--upload_data_to should follow the pattern ' \
-        '<dataset_id>:<table_id>:<location>')
+            '<project_id>:<dataset_id>:<table_id>:<location>')
 
-  @flagsaver.flagsaver(upload_data_to='correct:flag:pattern')
+  @flagsaver.flagsaver(upload_data_to='project:correct:flag:pattern')
   @mock.patch.object(benchmark.os, 'environ', return_value={})
   def test_upload_data_to_no_credentials(self, _):
     with self.assertRaises(ValueError) as context:

--- a/utils/output_handling.py
+++ b/utils/output_handling.py
@@ -71,15 +71,15 @@ def upload_csv(csv_file_path, bigquery_cfg):
   Args:
     csv_file_path: the path to the csv to be uploaded.
     bigquery_cfg: The string representing the BigQuery table config. Comes in
-      the form <dataset_id>:<table_id>:<location>
+      the form <project_id>:<dataset_id>:<table_id>:<location>
   """
   # This is a workaround for
   # https://github.com/bazelbuild/rules_python/issues/14
   from google.cloud import bigquery
 
   logger.log('Uploading the data to bigquery.')
-  client = bigquery.Client()
-  dataset_id, table_id, location = bigquery_cfg.split(':')
+  project_id, dataset_id, table_id, location = bigquery_cfg.split(':')
+  client = bigquery.Client(project=project_id)
 
   dataset_ref = client.dataset(dataset_id)
   table_ref = dataset_ref.table(table_id)


### PR DESCRIPTION
**What this PR does and why we need it:**

We need to specify the project id in BQ's client to connect to the correct project.
Otherwise, this value is interpreted from GOOGLE_APPLICATION_CREDENTIALS, which is not always what we want.