### PR TITLE
Remove GCP Credentials check

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -391,10 +391,6 @@ def _flag_checks():
       raise ValueError('--upload_data_to should follow the pattern '
                        '<project_id>:<dataset_id>:<table_id>:<location>')
 
-    if ('GOOGLE_APPLICATION_CREDENTIALS' not in os.environ or
-        not os.environ['GOOGLE_APPLICATION_CREDENTIALS']):
-      raise ValueError('GOOGLE_APPLICATION_CREDENTIALS is required to '
-                       'upload data to bigquery.')
     if FLAGS.collect_json_profile and not FLAGS.data_directory:
       raise ValueError('--collect_json_profile requires '
                        '--data_directory to be set')

--- a/benchmark_test.py
+++ b/benchmark_test.py
@@ -267,17 +267,5 @@ class BenchmarkFlagsTest(absltest.TestCase):
         '--upload_data_to should follow the pattern ' \
             '<project_id>:<dataset_id>:<table_id>:<location>')
 
-  @flagsaver.flagsaver(upload_data_to='project:correct:flag:pattern')
-  @mock.patch.object(benchmark.os, 'environ', return_value={})
-  def test_upload_data_to_no_credentials(self, _):
-    with self.assertRaises(ValueError) as context:
-      benchmark._flag_checks()
-    value_err = context.exception
-    self.assertEqual(
-        value_err.message,
-        'GOOGLE_APPLICATION_CREDENTIALS is required to upload data to bigquery.'
-    )
-
-
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
**What this PR does and why we need it:**

This PR removes the sanity check for GOOGLE_APPLICATION_CREDENTIALS in the environment since our BazelCI Ubuntu VMs doesn't have that value set.

**Does this require a change in the script's interface or the BigQuery's table structure?**

No.
