### PR TITLE
Fix incompatibilities with --incompatible_use_python_toolchains

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,4 +1,5 @@
 load("@third_party//:requirements.bzl", "requirement")
+load("@bazel_tools//tools/python:toolchain.bzl", "py_runtime_pair")
 
 py_binary(
     name = "benchmark",
@@ -14,6 +15,7 @@ py_binary(
 py_test(
     name = "benchmark_test",
     srcs = ["benchmark_test.py"],
+    python_version = "PY2",
     deps = [
         ":benchmark",
         "//testutils",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,8 +2,8 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 git_repository(
     name = "io_bazel_rules_python",
+    commit = "fdbb17a4118a1728d19e638a5291b4c4266ea5b8",
     remote = "https://github.com/bazelbuild/rules_python.git",
-    commit = "965d4b4a63e6462204ae671d7c3f02b25da37941",
 )
 
 # Only needed for PIP support:
@@ -21,4 +21,5 @@ pip_import(
 # Load the pip_install symbol for my_deps, and create the dependencies'
 # repositories.
 load("@third_party//:requirements.bzl", "pip_install")
+
 pip_install()

--- a/third_party/requirements.txt
+++ b/third_party/requirements.txt
@@ -4,7 +4,7 @@ certifi==2018.11.29
 chardet==3.0.4
 enum34==1.1.6
 funcsigs==1.0.2
-futures==3.2.0
+futures==3.1.1
 gitdb2==2.0.0
 GitPython==2.1.11
 google-api-core==1.8.0
@@ -15,7 +15,7 @@ google-resumable-media==0.3.2
 googleapis-common-protos==1.5.8
 idna==2.8
 mock==2.0.0
-numpy==1.16.1
+numpy==1.16.4
 pbr==5.1.3
 protobuf==3.6.1
 psutil==5.5.1

--- a/utils/BUILD
+++ b/utils/BUILD
@@ -1,4 +1,5 @@
 load("@third_party//:requirements.bzl", "requirement")
+load("@bazel_tools//tools/python:toolchain.bzl", "py_runtime_pair")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -49,6 +50,7 @@ py_test(
     name = "bazel_args_parser_test",
     size = "small",
     srcs = ["bazel_args_parser_test.py"],
+    python_version = "PY2",
     deps = [
         ":utils",
         requirement("mock"),
@@ -59,6 +61,7 @@ py_test(
     name = "bazel_test",
     size = "small",
     srcs = ["bazel_test.py"],
+    python_version = "PY2",
     deps = [
         ":utils",
         requirement("mock"),
@@ -69,6 +72,7 @@ py_test(
     name = "values_test",
     size = "small",
     srcs = ["values_test.py"],
+    python_version = "PY2",
     deps = [
         ":utils",
         requirement("mock"),


### PR DESCRIPTION
**What this PR does and why we need it:**

Fixes #29. Specify python version to run with the test targets.

Verified locally with Bazel 0.27 and with ` --incompatible_use_python_toolchains` enabled.

