### PR TITLE
Add json-profile-merger tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ bazel run utils:json_profile_merger \
 --project_source=<some url or path> \
 --project_commit=<some_commit> \
 --output_path=/tmp/outfile.csv \
---upload_data_to=<project_id>:<dataset_id>:<table_id>:location \
+--upload_data_to=<project_id>:<dataset_id>:<table_id>:<location> \
 -- /tmp/my_json_profiles_*.profile
 ```
 

--- a/README.md
+++ b/README.md
@@ -115,9 +115,35 @@ Some useful flags are:
     Requires --data_directory to be set.
     (default: 'false')
 ```
+
 ## Collecting JSON Profile
 
 [Bazel's JSON Profile](https://docs.bazel.build/versions/master/skylark/performance.html#json-profile) is a useful tool to investigate the performance of Bazel. You can configure `bazel-bench` to export these JSON profiles on runs using the `--collect_json_profile` flag.
+
+### JSON Profile Aggregation
+
+For each pair of `project_commit` and `bazel_commit`, we produce a couple JSON
+profiles, based on the number of runs. To have a better overview of the
+performance of each phase and events, we can aggregate these profiles and
+produce the median duration of each event across them.
+
+To run the tool:
+
+```
+bazel run utils:json_profile_merger \
+-- \
+--bazel_source=<some commit or path> \
+--project_source=<some url or path> \
+--project_commit=<some_commit> \
+--output_path=/tmp/outfile.csv \
+--upload_data_to=<project_id>:<dataset_id>:<table_id>:location \
+-- /tmp/my_json_profiles_*.profile
+```
+
+You can pass the pattern that selects the input profiles into the positional
+argument of the script, like in the above example
+(`/tmp/my_json_profiles_*.profile`).
+
 
 ## Uploading to BigQuery
 

--- a/benchmark.py
+++ b/benchmark.py
@@ -496,7 +496,8 @@ def main(argv):
         FLAGS.project_source,
         FLAGS.platform)
     if FLAGS.upload_data_to:
-      upload_csv(csv_file_path, FLAGS.upload_data_to)
+      project_id, dataset_id, table_id, location = FLAGS.upload_data_to
+      upload_csv(csv_file_path, project_id, dataset_id, table_id, location)
 
   logger.log('Done.')
 

--- a/utils/BUILD
+++ b/utils/BUILD
@@ -7,7 +7,10 @@ filegroup(
     name = "utils-srcs",
     srcs = glob(
         ["*.py"],
-        exclude = ["*_test.py"],
+        exclude = [
+            "*_test.py",
+            "json_profile_merger.py",
+        ],
     ),
 )
 
@@ -46,6 +49,15 @@ py_library(
     ],
 )
 
+py_binary(
+    name = "json_profiles_merger",
+    srcs = ["json_profiles_merger.py"],
+    deps = [
+        ":utils",
+        requirement("absl-py"),
+    ],
+)
+
 py_test(
     name = "bazel_args_parser_test",
     size = "small",
@@ -72,6 +84,17 @@ py_test(
     name = "values_test",
     size = "small",
     srcs = ["values_test.py"],
+    python_version = "PY2",
+    deps = [
+        ":utils",
+        requirement("mock"),
+    ],
+)
+
+py_test(
+    name = "json_profiles_merger_lib_test",
+    size = "small",
+    srcs = ["json_profiles_merger_lib_test.py"],
     python_version = "PY2",
     deps = [
         ":utils",

--- a/utils/json_profiles_merger.py
+++ b/utils/json_profiles_merger.py
@@ -19,15 +19,15 @@ import json_profiles_merger_lib as lib
 import output_handling
 
 FLAGS = flags.FLAGS
-flags.DEFINE_string('output_path', None, 'The path to the output file')
+flags.DEFINE_string('output_path', None, 'The path to the output file.')
 flags.DEFINE_string(
     'bazel_source', None,
     ('(Optional) The bazel commit or path to the bazel binary from which these'
-     'JSON profiles were collected'))
+     'JSON profiles were collected.'))
 flags.DEFINE_string(
     'project_source', None,
     ('(Optional) The project on which the runs that generated these JSON'
-     'profiles were performed'))
+     'profiles were performed.'))
 flags.DEFINE_string(
     'project_commit', None,
     '(Optional) The project commit on which the Bazel runs were performed.')

--- a/utils/json_profiles_merger.py
+++ b/utils/json_profiles_merger.py
@@ -1,0 +1,61 @@
+r"""A simple script to aggregate JSON profiles.
+
+Collect median duration of events across these profiles.
+
+Usage:
+  bazel run json_profiles_merger -- \
+  --bazel_source=/usr/bin/bazel \
+  --project=https://github.com/bazelbuild/bazel \
+  --project_commit=2 \
+  --output_path=/tmp/median_dur.csv \
+  --upload_data_to=project-id:dataset-id:table-id:location \
+  -- \
+  *.profile
+"""
+from absl import app
+from absl import flags
+
+import json_profiles_merger_lib as lib
+import output_handling
+
+FLAGS = flags.FLAGS
+flags.DEFINE_string('output_path', None, 'The path to the output file')
+flags.DEFINE_string(
+    'bazel_source', None,
+    ('(Optional) The bazel commit or path to the bazel binary from which these'
+     'JSON profiles were collected'))
+flags.DEFINE_string(
+    'project_source', None,
+    ('(Optional) The project on which the runs that generated these JSON'
+     'profiles were performed'))
+flags.DEFINE_string(
+    'project_commit', None,
+    '(Optional) The project commit on which the Bazel runs were performed.')
+flags.DEFINE_string(
+    'upload_data_to', None,
+    'Uploads data to bigquery, requires output_path to be set. '
+    'The details of the BigQuery table to upload results to specified in '
+    'the form: <project_id>:<dataset_id>:<table_id>:<location>.')
+
+
+def main(argv):
+  # Discard the first argument (the binary).
+  input_profiles = argv[1:]
+  lib.aggregate_data(
+      FLAGS.bazel_source,
+      FLAGS.project_source,
+      FLAGS.project_commit,
+      input_profiles,
+      FLAGS.output_path)
+  if FLAGS.upload_data_to:
+    project_id, dataset_id, table_id, location = FLAGS.upload_data_to.split(':')
+    output_handling.upload_csv(
+        csv_file_path=FLAGS.output_path,
+        project_id=project_id,
+        dataset_id=dataset_id,
+        table_id=table_id,
+        location=location)
+
+
+if __name__ == '__main__':
+  app.run(main)

--- a/utils/json_profiles_merger_lib.py
+++ b/utils/json_profiles_merger_lib.py
@@ -67,10 +67,14 @@ def _accumulate_event_duration(event_list, accum_dict):
   """
   # A list of tuples of the form (marker, occurrence time in micro s)
   build_markers_ts_pairs = []
+  max_ts = 0
 
   # Only collect events with a duration.
   # Special case: markers that indicates beginning/end of execution.
   for event in event_list:
+    if 'ts' in event:
+      max_ts = max(max_ts, event['ts'])
+
     if 'cat' in event and event['cat'] == 'build phase marker':
       build_markers_ts_pairs.append((event['name'], event['ts']))
 
@@ -84,6 +88,11 @@ def _accumulate_event_duration(event_list, accum_dict):
           'dur_list': []
       }
     accum_dict[event['name']]['dur_list'].append(event['dur'])
+
+  # Append an artificial marker that signifies the end of the run.
+  # This is to determine the duration from the last marker to the actual end of
+  # the run and will not end up in the final data.
+  build_markers_ts_pairs.append((None, max_ts))
 
   # Fill in the markers.
   for i, marker_ts_pair in enumerate(build_markers_ts_pairs[:-1]):

--- a/utils/json_profiles_merger_lib.py
+++ b/utils/json_profiles_merger_lib.py
@@ -1,0 +1,173 @@
+"""A library that holds the bulk of the logic for merging JSON profiles.
+
+Collect median duration of events across these profiles.
+"""
+from __future__ import division
+
+import csv
+import gzip
+import json
+import os
+
+
+def _median(lst):
+  """Returns the median of the input list.
+
+  Args:
+    lst: the input list.
+
+  Returns:
+    The median of the list, or None if the list is empty/None.
+  """
+  sorted_lst = sorted(lst)
+  length = len(sorted_lst)
+  if length % 2:
+    return sorted_lst[length // 2]
+  return (sorted_lst[length // 2 - 1] + sorted_lst[length // 2]) / 2
+
+
+def _write_to_csv(
+    bazel_source, project_source, project_commit, event_list, output_csv_path):
+  """Writes the event_list to output_csv_path.
+
+  event_list format:
+  [{'cat': <string>, 'name': <string>, 'dur': <int>}, ...]
+
+  Args:
+    bazel_source: the bazel commit or path to the bazel binary from which these
+      JSON profiles were collected.
+    project_source: the project on which the runs that generated these JSON
+      projects were performed.
+    project_commit: the project commit on which the Bazel runs were performed.
+    event_list: the list of events, aggregated from the JSON profiles.
+    output_csv_path: a path to the output CSV file.
+  """
+  with open(output_csv_path, 'w') as csv_file:
+    csv_writer = csv.writer(csv_file)
+    csv_writer.writerow(
+        ['bazel_source', 'project_source', 'project_commit',
+         'cat', 'name', 'dur'])
+
+    for event in event_list:
+      csv_writer.writerow(
+          [bazel_source, project_source, project_commit,
+           event['cat'], event['name'], event['dur']])
+
+
+def _accumulate_event_duration(event_list, accum_dict):
+  """Fill up accum_dict by accummulating durations of each event.
+
+  Also create the entries for each phase by subtracting the build phase markers'
+  ts attribute.
+
+  Args:
+    event_list: the list of event objects.
+    accum_dict: the dict to be filled up with a mapping of the following format:
+      { <name>: { name: ..., cat: ..., dur_list: [...]}, ...}
+  """
+  # A list of tuples of the form (marker, occurrence time in micro s)
+  build_markers_ts_pairs = []
+
+  # Only collect events with a duration.
+  # Special case: markers that indicates beginning/end of execution.
+  for event in event_list:
+    if 'cat' in event and event['cat'] == 'build phase marker':
+      build_markers_ts_pairs.append((event['name'], event['ts']))
+
+    if 'dur' not in event:
+      continue
+
+    if event['name'] not in accum_dict:
+      accum_dict[event['name']] = {
+          'name': event['name'],
+          'cat': event['cat'],
+          'dur_list': []
+      }
+    accum_dict[event['name']]['dur_list'].append(event['dur'])
+
+  # Fill in the markers.
+  for i, marker_ts_pair in enumerate(build_markers_ts_pairs[:-1]):
+    marker, ts = marker_ts_pair
+    _, next_ts = build_markers_ts_pairs[i + 1]
+
+    if marker not in accum_dict:
+      accum_dict[marker] = {
+          'name': marker,
+          'cat': 'build phase marker',
+          'dur_list': []
+      }
+    current_phase_duration_millis = (next_ts - ts) / 1000
+    accum_dict[marker]['dur_list'].append(current_phase_duration_millis)
+
+
+def _aggregate_from_accum_dict(accum_dict):
+  """Aggregate the result from the accummulated dict.
+
+  Calculate the median of the durations for each event.
+
+  Args:
+    accum_dict: the dict to be filled up with a mapping of the following format:
+      { <name>: { name: ..., cat: ..., dur_list: [...]}, ...}
+
+  Returns:
+    A list of the following format:
+      [{ name: ..., cat: ..., dur: ... }]
+  """
+  result = []
+  for obj in accum_dict.values():
+    result.append({
+        'name': obj['name'],
+        'cat': obj['cat'],
+        'dur': _median(obj['dur_list'])
+    })
+  return result
+
+
+def aggregate_data(
+    bazel_source, project_source, project_commit, input_profiles, output_path):
+  """Produces the aggregated data from the JSON profile inputs.
+
+  Collects information on cat, name and median duration of the events in the
+  JSON profiles.
+  Writes the result to output_path.
+
+  Args:
+    bazel_source: the bazel commit or path to the bazel binary from which these
+      JSON profiles were collected.
+    project_source: the project on which the runs that generated these JSON
+      projects were performed.
+    project_commit: the project commit on which the Bazel runs were performed.
+    input_profiles: a list of paths to .profile or .profile.gz files.
+    output_path: a path to the output file.
+  """
+  # A map from event name to an object which accumulates the durations.
+  accum_dict = dict()
+  for file_path in input_profiles:
+    if file_path.endswith('.gz'):
+      with gzip.GzipFile(file_path, 'r') as gz_input_file:
+        event_list = json.loads(gz_input_file.read().decode('utf-8'))
+    else:
+      with open(file_path, 'r') as input_file:
+        event_list = json.load(input_file)
+
+    # The events in the JSON profiles can be presented directly as a list,
+    # or as the value of key 'traceEvents'.
+    if 'traceEvents' in event_list:
+      event_list = event_list['traceEvents']
+    _accumulate_event_duration(event_list, accum_dict)
+
+  # The list of objects which contain the info about cat, name and median
+  # duration of events.
+  aggregated_data = _aggregate_from_accum_dict(accum_dict)
+
+  output_dir = os.path.dirname(output_path)
+  if not os.path.exists(output_dir):
+    os.makedirs(output_dir)
+
+  _write_to_csv(
+      bazel_source,
+      project_source,
+      project_commit,
+      aggregated_data,
+      output_path)
+

--- a/utils/json_profiles_merger_lib_test.py
+++ b/utils/json_profiles_merger_lib_test.py
@@ -69,6 +69,7 @@ class JsonProfilesMergerLibTest(unittest.TestCase):
             'cat': 'fake_cat',
             'name': 'fake_name',
             'dur': 1,
+            'ts': 10001,
             'non_dur': 'something'
         },
     ]
@@ -81,6 +82,11 @@ class JsonProfilesMergerLibTest(unittest.TestCase):
                 'cat': 'build phase marker',
                 'name': 'phase1',
                 'dur_list': [9.0]
+            },
+            'phase2': {
+                'cat': 'build phase marker',
+                'name': 'phase2',
+                'dur_list': [0.001]
             },
             'fake_name': {
                 'cat': 'fake_cat',

--- a/utils/json_profiles_merger_lib_test.py
+++ b/utils/json_profiles_merger_lib_test.py
@@ -1,0 +1,109 @@
+"""Tests for json_profiles_merger_lib."""
+
+import json_profiles_merger_lib as lib
+import unittest
+
+class JsonProfilesMergerLibTest(unittest.TestCase):
+
+  def test_accumulate_event_duration(self):
+    event_list_1 = [
+        {
+            'name': 'to_skip_no_dur',
+        },
+        {
+            'cat': 'fake_cat',
+            'name': 'fake_name',
+            'dur': 3,
+            'non_dur': 'something'
+        },
+    ]
+
+    event_list_2 = [
+        {
+            'name': 'to_skip_no_dur',
+        },
+        {
+            'cat': 'fake_cat',
+            'name': 'fake_name',
+            'dur': 1,
+            'non_dur': 'something'
+        },
+    ]
+
+    accum_dict = {}
+    lib._accumulate_event_duration(event_list_1, accum_dict)
+    self.assertEqual(
+        {
+            'fake_name': {
+                'cat': 'fake_cat',
+                'name': 'fake_name',
+                'dur_list': [3]
+            },
+        }, accum_dict)
+    lib._accumulate_event_duration(event_list_2, accum_dict)
+    self.assertEqual(
+        {
+            'fake_name': {
+                'cat': 'fake_cat',
+                'name': 'fake_name',
+                'dur_list': [3, 1]
+            }
+        }, accum_dict)
+
+  def test_accumulate_build_phase_marker(self):
+    event_list_3 = [
+        {
+            'name': 'to_skip_no_dur',
+        },
+        {
+            'cat': 'build phase marker',
+            'name': 'phase1',
+            'ts': 1000
+        },
+        {
+            'cat': 'build phase marker',
+            'name': 'phase2',
+            'ts': 10000
+        },
+        {
+            'cat': 'fake_cat',
+            'name': 'fake_name',
+            'dur': 1,
+            'non_dur': 'something'
+        },
+    ]
+
+    accum_dict = {}
+    lib._accumulate_event_duration(event_list_3, accum_dict)
+    self.assertEqual(
+        {
+            'phase1': {
+                'cat': 'build phase marker',
+                'name': 'phase1',
+                'dur_list': [9.0]
+            },
+            'fake_name': {
+                'cat': 'fake_cat',
+                'name': 'fake_name',
+                'dur_list': [1]
+            },
+        }, accum_dict)
+
+  def test_aggregate_from_accum_dict(self):
+    accum_dict = {
+        'fake_name': {
+            'cat': 'fake_cat',
+            'name': 'fake_name',
+            'dur_list': [3, 1]
+        },
+    }
+
+    self.assertEqual([{
+        'cat': 'fake_cat',
+        'name': 'fake_name',
+        'dur': 2.0
+    }], lib._aggregate_from_accum_dict(accum_dict))
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/utils/output_handling.py
+++ b/utils/output_handling.py
@@ -63,22 +63,23 @@ def export_csv(data_directory, filename, data, project_source, platform):
   return csv_file_path
 
 
-def upload_csv(csv_file_path, bigquery_cfg):
+def upload_csv(csv_file_path, project_id, dataset_id, table_id, location):
   """Uploads the csv file to BigQuery.
 
   Takes the configuration from config.json.
 
   Args:
     csv_file_path: the path to the csv to be uploaded.
-    bigquery_cfg: The string representing the BigQuery table config. Comes in
-      the form <project_id>:<dataset_id>:<table_id>:<location>
+    project_id: the BigQuery project id.
+    dataset_id: the BigQuery dataset id.
+    table_id: the BigQuery table id.
+    location: the BigQuery table's location.
   """
   # This is a workaround for
   # https://github.com/bazelbuild/rules_python/issues/14
   from google.cloud import bigquery
 
   logger.log('Uploading the data to bigquery.')
-  project_id, dataset_id, table_id, location = bigquery_cfg.split(':')
   client = bigquery.Client(project=project_id)
 
   dataset_ref = client.dataset(dataset_id)


### PR DESCRIPTION
**What this PR does and why we need it:**

This PR adds a tool to merge JSON profiles that we collect and present an aggregation (median) of the event durations.

Next step: Incorporate this into bazel-bench-nightly as the final step.

**New changes / Issues that this PR fixes:**

- Add json_profile_merger tool.
- Change upload_csv signature to detach flag parsing logic.
- Update README.

**Does this require a change in the script's interface or the BigQuery's table structure?**

Yes. Create a new table `json_profiles_aggr`.
