### PR TITLE
Upload CSV output to Storage

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,6 +1,7 @@
 load("@third_party//:requirements.bzl", "requirement")
 load("@bazel_tools//tools/python:toolchain.bzl", "py_runtime_pair")
 
+# TODO(https://github.com/bazelbuild/bazel-bench/issues/36): Make these work for python3.
 py_binary(
     name = "benchmark",
     srcs = ["benchmark.py"],

--- a/BUILD
+++ b/BUILD
@@ -4,8 +4,11 @@ load("@bazel_tools//tools/python:toolchain.bzl", "py_runtime_pair")
 py_binary(
     name = "benchmark",
     srcs = ["benchmark.py"],
+    python_version = "PY2",
     deps = [
         "//utils",
+        "//utils:bigquery_upload",
+        "//utils:storage_upload",
         requirement("absl-py"),
         requirement("GitPython"),
         requirement("gitdb2"),

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Some useful flags are:
   --bazelrc: The path to a .bazelrc file.
   --[no]collect_memory: Whether to collect used heap sizes.
     (default: 'false')
+  --csv_file_name: The name of the output csv, without the .csv extension
   --data_directory: The directory in which the csv files should be stored. Turns on memory collection.
   --[no]prefetch_ext_deps: Whether to do an initial run to pre-fetch external dependencies.
     (default: 'true')
@@ -109,6 +110,7 @@ Some useful flags are:
     (default: '3')
     (an integer)
   --upload_to_bigquery: The details of the BigQuery table to upload results to: <project_id>:<dataset_id>:<table_id>:<location>
+  --upload_to_storage: The details of the GCP Storage bucket to upload results to: <project_id>:<bucket_id>:<subdirectory>
   --[no]verbose: Whether to include git/Bazel stdout logs.
     (default: 'false')
   --[no]collect_json_profile: Whether to collect JSON profile for each run.

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Some useful flags are:
   --runs: The number of benchmark runs.
     (default: '3')
     (an integer)
-  --upload_data_to: The details of the BigQuery table to upload results to: <project_id>:<dataset_id>:<table_id>:<location>
+  --upload_to_bigquery: The details of the BigQuery table to upload results to: <project_id>:<dataset_id>:<table_id>:<location>
   --[no]verbose: Whether to include git/Bazel stdout logs.
     (default: 'false')
   --[no]collect_json_profile: Whether to collect JSON profile for each run.
@@ -136,7 +136,7 @@ bazel run utils:json_profile_merger \
 --project_source=<some url or path> \
 --project_commit=<some_commit> \
 --output_path=/tmp/outfile.csv \
---upload_data_to=<project_id>:<dataset_id>:<table_id>:<location> \
+--upload_to_bigquery=<project_id>:<dataset_id>:<table_id>:<location> \
 -- /tmp/my_json_profiles_*.profile
 ```
 
@@ -145,9 +145,9 @@ argument of the script, like in the above example
 (`/tmp/my_json_profiles_*.profile`).
 
 
-## Uploading to BigQuery
+## Uploading to BigQuery & Storage
 
-To upload the output to BigQuery, you'll need the GCP credentials and the table
+To upload the output to BigQuery & Storage you'll need the GCP credentials and the table
 details. Please contact leba@google.com.
 
 ## Tests

--- a/benchmark.py
+++ b/benchmark.py
@@ -375,7 +375,7 @@ flags.DEFINE_boolean('collect_json_profile', False,
 flags.DEFINE_string('data_directory', None,
                     'The directory in which the csv files should be stored. ' \
                     'Turns on memory collection.')
-flags.DEFINE_string('upload_to_bq', None,
+flags.DEFINE_string('upload_to_bigquery', None,
                     'The details of the BigQuery table to upload ' \
                     'results to: <project_id>:<dataset_id>:<table_id>:<location>')
 flags.DEFINE_string('upload_to_storage', None,
@@ -395,9 +395,9 @@ def _flag_checks():
         'Either --bazel_commits or --project_commits should be a single element.'
     )
 
-  if FLAGS.upload_to_bq:
-    if not re.match('^[\w-]+:[\w-]+:[\w-]+:[\w-]+$', FLAGS.upload_to_bq):
-      raise ValueError('--upload_to_bq should follow the pattern '
+  if FLAGS.upload_to_bigquery:
+    if not re.match('^[\w-]+:[\w-]+:[\w-]+:[\w-]+$', FLAGS.upload_to_bigquery):
+      raise ValueError('--upload_to_bigquery should follow the pattern '
                        '<project_id>:<dataset_id>:<table_id>:<location>.')
 
   if FLAGS.upload_to_storage:
@@ -504,7 +504,7 @@ def main(argv):
              values.stddev(), pval))
     last_collected = collected
 
-  if FLAGS.data_directory or FLAGS.upload_to_bq or FLAGS.upload_to_storage:
+  if FLAGS.data_directory or FLAGS.upload_to_bigquery or FLAGS.upload_to_storage:
     csv_file_name = FLAGS.csv_file_name or bazel_bench_uid
 
     csv_file_path = output_handling.export_csv(
@@ -514,9 +514,9 @@ def main(argv):
         FLAGS.project_source,
         FLAGS.platform)
 
-    if FLAGS.upload_to_bq:
-      project_id, dataset_id, table_id, location = FLAGS.upload_to_bq.split(':')
-      bigquery_upload.upload_to_bq(
+    if FLAGS.upload_to_bigquery:
+      project_id, dataset_id, table_id, location = FLAGS.upload_to_bigquery.split(':')
+      bigquery_upload.upload_to_bigquery(
           csv_file_path, project_id, dataset_id, table_id, location)
 
     if FLAGS.upload_to_storage:

--- a/benchmark.py
+++ b/benchmark.py
@@ -25,6 +25,8 @@ import git
 import utils.logger as logger
 import utils.bazel_args_parser as args_parser
 import utils.output_handling as output_handling
+import utils.bigquery_upload as bigquery_upload
+import utils.storage_upload as storage_upload
 
 from absl import app
 from absl import flags
@@ -513,14 +515,14 @@ def main(argv):
         FLAGS.platform)
 
     if FLAGS.upload_to_bq:
-      project_id, dataset_id, table_id, location = FLAGS.upload_to_bq
-      output_handling.upload_to_bq(
+      project_id, dataset_id, table_id, location = FLAGS.upload_to_bq.split(':')
+      bigquery_upload.upload_to_bq(
           csv_file_path, project_id, dataset_id, table_id, location)
 
     if FLAGS.upload_to_storage:
-      project_id, bucket_id, subdirectory = FLAGS.upload_to_storage
+      project_id, bucket_id, subdirectory = FLAGS.upload_to_storage.split(':')
       destination = "%s/%s.csv" % (subdirectory, csv_file_name)
-      output_handling.upload_to_storage(
+      storage_upload.upload_to_storage(
           csv_file_path, project_id, bucket_id, destination)
 
   logger.log('Done.')

--- a/benchmark.py
+++ b/benchmark.py
@@ -24,6 +24,7 @@ import tempfile
 import git
 import utils.logger as logger
 import utils.bazel_args_parser as args_parser
+import utils.output_handling as output_handling
 
 from absl import app
 from absl import flags
@@ -31,7 +32,6 @@ from absl.flags import argparse_flags
 
 from utils.values import Values
 from utils.bazel import Bazel
-from utils.output_handling import export_csv, upload_csv
 
 # TMP has different values, depending on the platform.
 TMP = tempfile.gettempdir()
@@ -373,10 +373,17 @@ flags.DEFINE_boolean('collect_json_profile', False,
 flags.DEFINE_string('data_directory', None,
                     'The directory in which the csv files should be stored. ' \
                     'Turns on memory collection.')
-flags.DEFINE_string('upload_data_to', None,
+flags.DEFINE_string('upload_to_bq', None,
                     'The details of the BigQuery table to upload ' \
                     'results to: <project_id>:<dataset_id>:<table_id>:<location>')
-
+flags.DEFINE_string('upload_to_storage', None,
+                    'The details of the GCP Storage bucket to upload ' \
+                    'results to: <project_id>:<bucket_id>:<subdirectory>.')
+# The daily report generation process on BazelCI requires the csv file name to
+# be determined before bazel-bench is launched, so that METADATA files are
+# properly filled.
+flags.DEFINE_string('csv_file_name', None,
+                    'The name of the output csv, without the .csv extension.')
 
 def _flag_checks():
   """Verify flags requirements."""
@@ -386,14 +393,21 @@ def _flag_checks():
         'Either --bazel_commits or --project_commits should be a single element.'
     )
 
-  if FLAGS.upload_data_to:
-    if not re.match('^[\w-]+:[\w-]+:[\w-]+:[\w-]+$', FLAGS.upload_data_to):
-      raise ValueError('--upload_data_to should follow the pattern '
-                       '<project_id>:<dataset_id>:<table_id>:<location>')
+  if FLAGS.upload_to_bq:
+    if not re.match('^[\w-]+:[\w-]+:[\w-]+:[\w-]+$', FLAGS.upload_to_bq):
+      raise ValueError('--upload_to_bq should follow the pattern '
+                       '<project_id>:<dataset_id>:<table_id>:<location>.')
 
-    if FLAGS.collect_json_profile and not FLAGS.data_directory:
-      raise ValueError('--collect_json_profile requires '
-                       '--data_directory to be set')
+  if FLAGS.upload_to_storage:
+    if not FLAGS.csv_file_name:
+      raise ValueError('--csv_file_name is required with --upload_to_storage.')
+    if not re.match('^[\w-]+:[\w-]+:[\w\/-]+$', FLAGS.upload_to_storage):
+      raise ValueError('--upload_to_storage should follow the pattern '
+                       '<project_id>:<bucket_id>:<subdirectory>.')
+
+  if FLAGS.collect_json_profile and not FLAGS.data_directory:
+    raise ValueError('--collect_json_profile requires '
+                     '--data_directory to be set.')
 
 
 def main(argv):
@@ -488,16 +502,26 @@ def main(argv):
              values.stddev(), pval))
     last_collected = collected
 
-  if FLAGS.data_directory or FLAGS.upload_data_to:
-    csv_file_path = export_csv(
+  if FLAGS.data_directory or FLAGS.upload_to_bq or FLAGS.upload_to_storage:
+    csv_file_name = FLAGS.csv_file_name or bazel_bench_uid
+
+    csv_file_path = output_handling.export_csv(
         data_directory,
-        bazel_bench_uid,
+        csv_file_name,
         csv_data,
         FLAGS.project_source,
         FLAGS.platform)
-    if FLAGS.upload_data_to:
-      project_id, dataset_id, table_id, location = FLAGS.upload_data_to
-      upload_csv(csv_file_path, project_id, dataset_id, table_id, location)
+
+    if FLAGS.upload_to_bq:
+      project_id, dataset_id, table_id, location = FLAGS.upload_to_bq
+      output_handling.upload_to_bq(
+          csv_file_path, project_id, dataset_id, table_id, location)
+
+    if FLAGS.upload_to_storage:
+      project_id, bucket_id, subdirectory = FLAGS.upload_to_storage
+      destination = "%s/%s.csv" % (subdirectory, csv_file_name)
+      output_handling.upload_to_storage(
+          csv_file_path, project_id, bucket_id, destination)
 
   logger.log('Done.')
 

--- a/benchmark_test.py
+++ b/benchmark_test.py
@@ -257,15 +257,36 @@ class BenchmarkFlagsTest(absltest.TestCase):
         'Either --bazel_commits or --project_commits should be a single element.'
     )
 
-  @flagsaver.flagsaver(upload_data_to='wrong_pattern')
-  def test_upload_data_to_wrong_pattern(self):
+  @flagsaver.flagsaver(upload_to_bq='wrong_pattern')
+  def test_upload_to_bq_wrong_pattern(self):
     with self.assertRaises(ValueError) as context:
       benchmark._flag_checks()
     value_err = context.exception
     self.assertEqual(
         value_err.message,
-        '--upload_data_to should follow the pattern ' \
-            '<project_id>:<dataset_id>:<table_id>:<location>')
+        '--upload_to_bq should follow the pattern ' \
+            '<project_id>:<dataset_id>:<table_id>:<location>.')
+
+  @flagsaver.flagsaver(upload_to_storage='wrong_pattern')
+  @flagsaver.flagsaver(csv_file_name='dummy')
+  def test_upload_to_storage_wrong_pattern(self):
+    with self.assertRaises(ValueError) as context:
+      benchmark._flag_checks()
+    value_err = context.exception
+    self.assertEqual(
+        value_err.message,
+        '--upload_to_storage should follow the pattern ' \
+            '<project_id>:<bucket_id>:<subdirectory>.')
+
+  @flagsaver.flagsaver(upload_to_storage='wrong_pattern')
+  def test_upload_to_storage_missing_csv_file_name(self):
+    with self.assertRaises(ValueError) as context:
+      benchmark._flag_checks()
+    value_err = context.exception
+    self.assertEqual(
+        value_err.message,
+        '--csv_file_name is required with --upload_to_storage.')
+
 
 if __name__ == '__main__':
   absltest.main()

--- a/benchmark_test.py
+++ b/benchmark_test.py
@@ -257,14 +257,14 @@ class BenchmarkFlagsTest(absltest.TestCase):
         'Either --bazel_commits or --project_commits should be a single element.'
     )
 
-  @flagsaver.flagsaver(upload_to_bq='wrong_pattern')
-  def test_upload_to_bq_wrong_pattern(self):
+  @flagsaver.flagsaver(upload_to_bigquery='wrong_pattern')
+  def test_upload_to_bigquery_wrong_pattern(self):
     with self.assertRaises(ValueError) as context:
       benchmark._flag_checks()
     value_err = context.exception
     self.assertEqual(
         value_err.message,
-        '--upload_to_bq should follow the pattern ' \
+        '--upload_to_bigquery should follow the pattern ' \
             '<project_id>:<dataset_id>:<table_id>:<location>.')
 
   @flagsaver.flagsaver(upload_to_storage='wrong_pattern')

--- a/third_party/requirements.txt
+++ b/third_party/requirements.txt
@@ -10,6 +10,7 @@ GitPython==2.1.11
 google-api-core==1.8.0
 google-auth==1.6.3
 google-cloud-bigquery==1.9.0
+google-cloud-storage==1.13.2
 google-cloud-core==0.29.1
 google-resumable-media==0.3.2
 googleapis-common-protos==1.5.8

--- a/utils/BUILD
+++ b/utils/BUILD
@@ -10,6 +10,8 @@ filegroup(
         exclude = [
             "*_test.py",
             "json_profile_merger.py",
+            "bigquery_upload.py",
+            "storage_upload.py",
         ],
     ),
 )
@@ -25,18 +27,9 @@ py_library(
         requirement("enum34"),
         requirement("funcsigs"),
         requirement("futures"),
-        # This is a workaround for https://github.com/bazelbuild/rules_python/issues/14,
-        # google-cloud-bigquery must be listed first.
-        requirement("google-cloud-bigquery"),
-        requirement("google-api-core"),
-        requirement("google-auth"),
-        requirement("google-cloud-core"),
-        requirement("google-resumable-media"),
-        requirement("googleapis-common-protos"),
         requirement("idna"),
         requirement("numpy"),
         requirement("pbr"),
-        requirement("protobuf"),
         requirement("psutil"),
         requirement("pyasn1"),
         requirement("pyasn1-modules"),
@@ -46,6 +39,40 @@ py_library(
         requirement("scipy"),
         requirement("six"),
         requirement("urllib3"),
+    ],
+)
+
+py_library(
+    name = "google-common",
+    deps = [
+        requirement("google-api-core"),
+        requirement("google-auth"),
+        requirement("google-cloud-core"),
+        requirement("google-resumable-media"),
+        requirement("googleapis-common-protos"),
+        requirement("protobuf"),
+    ],
+)
+
+py_library(
+    name = "bigquery_upload",
+    srcs = ["bigquery_upload.py"],
+    deps = [
+        # This is a workaround for https://github.com/bazelbuild/rules_python/issues/14,
+        # google-cloud-bigquery must be listed first.
+        requirement("google-cloud-bigquery"),
+        ":google-common",
+    ],
+)
+
+py_library(
+    name = "storage_upload",
+    srcs = ["storage_upload.py"],
+    deps = [
+        # This is a workaround for https://github.com/bazelbuild/rules_python/issues/14,
+        # google-cloud-storage must be listed first.
+        requirement("google-cloud-storage"),
+        ":google-common",
     ],
 )
 

--- a/utils/bigquery_upload.py
+++ b/utils/bigquery_upload.py
@@ -17,7 +17,7 @@ import logger
 import sys
 
 
-def upload_to_bq(csv_file_path, project_id, dataset_id, table_id, location):
+def upload_to_bigquery(csv_file_path, project_id, dataset_id, table_id, location):
   """Uploads the csv file to BigQuery.
 
   Takes the configuration from GOOGLE_APPLICATION_CREDENTIALS.

--- a/utils/bigquery_upload.py
+++ b/utils/bigquery_upload.py
@@ -1,0 +1,64 @@
+# Copyright 2019 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Handles the uploading of result CSV to BigQuery.
+"""
+import logger
+import sys
+
+from google.cloud import bigquery
+
+
+def upload_to_bq(csv_file_path, project_id, dataset_id, table_id, location):
+  """Uploads the csv file to BigQuery.
+
+  Takes the configuration from GOOGLE_APPLICATION_CREDENTIALS.
+
+  Args:
+    csv_file_path: the path to the csv to be uploaded.
+    project_id: the BigQuery project id.
+    dataset_id: the BigQuery dataset id.
+    table_id: the BigQuery table id.
+    location: the BigQuery table's location.
+  """
+  # This is a workaround for
+  # https://github.com/bazelbuild/rules_python/issues/14
+
+  logger.log('Uploading the data to bigquery.')
+  client = bigquery.Client(project=project_id)
+
+  dataset_ref = client.dataset(dataset_id)
+  table_ref = dataset_ref.table(table_id)
+
+  job_config = bigquery.LoadJobConfig()
+  job_config.source_format = bigquery.SourceFormat.CSV
+  job_config.skip_leading_rows = 1
+  job_config.autodetect = False
+
+  # load table to get schema
+  table = client.get_table(table_ref)
+  job_config.schema = table.schema
+
+  with open(str(csv_file_path), 'rb') as source_file:
+    job = client.load_table_from_file(
+        source_file, table_ref, location=location, job_config=job_config)
+
+  try:
+    job.result()  # Waits for table load to complete.
+  except Exception:
+    print('Uploading failed with: %s' % str(job.errors))
+    sys.exit(-1)
+  logger.log('Uploaded {} rows into {}:{}.'.format(job.output_rows, dataset_id,
+                                                   table_id))
+
+

--- a/utils/bigquery_upload.py
+++ b/utils/bigquery_upload.py
@@ -31,9 +31,6 @@ def upload_to_bq(csv_file_path, project_id, dataset_id, table_id, location):
     table_id: the BigQuery table id.
     location: the BigQuery table's location.
   """
-  # This is a workaround for
-  # https://github.com/bazelbuild/rules_python/issues/14
-
   logger.log('Uploading the data to bigquery.')
   client = bigquery.Client(project=project_id)
 

--- a/utils/bigquery_upload.py
+++ b/utils/bigquery_upload.py
@@ -16,8 +16,6 @@
 import logger
 import sys
 
-from google.cloud import bigquery
-
 
 def upload_to_bq(csv_file_path, project_id, dataset_id, table_id, location):
   """Uploads the csv file to BigQuery.
@@ -31,6 +29,9 @@ def upload_to_bq(csv_file_path, project_id, dataset_id, table_id, location):
     table_id: the BigQuery table id.
     location: the BigQuery table's location.
   """
+  # This is a workaround for https://github.com/bazelbuild/rules_python/issues/14
+  from google.cloud import bigquery
+
   logger.log('Uploading the data to bigquery.')
   client = bigquery.Client(project=project_id)
 

--- a/utils/output_handling.py
+++ b/utils/output_handling.py
@@ -11,9 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import print_function
-
-import sys
 import os
 import csv
 import socket
@@ -61,63 +58,4 @@ def export_csv(data_directory, filename, data, project_source, platform):
             platform
         ])
   return csv_file_path
-
-
-def upload_to_bq(csv_file_path, project_id, dataset_id, table_id, location):
-  """Uploads the csv file to BigQuery.
-
-  Takes the configuration from config.json.
-
-  Args:
-    csv_file_path: the path to the csv to be uploaded.
-    project_id: the BigQuery project id.
-    dataset_id: the BigQuery dataset id.
-    table_id: the BigQuery table id.
-    location: the BigQuery table's location.
-  """
-  # This is a workaround for
-  # https://github.com/bazelbuild/rules_python/issues/14
-  from google.cloud import bigquery
-
-  logger.log('Uploading the data to bigquery.')
-  client = bigquery.Client(project=project_id)
-
-  dataset_ref = client.dataset(dataset_id)
-  table_ref = dataset_ref.table(table_id)
-
-  job_config = bigquery.LoadJobConfig()
-  job_config.source_format = bigquery.SourceFormat.CSV
-  job_config.skip_leading_rows = 1
-  job_config.autodetect = False
-
-  # load table to get schema
-  table = client.get_table(table_ref)
-  job_config.schema = table.schema
-
-  with open(str(csv_file_path), 'rb') as source_file:
-    job = client.load_table_from_file(
-        source_file, table_ref, location=location, job_config=job_config)
-
-  try:
-    job.result()  # Waits for table load to complete.
-  except Exception:
-    print('Uploading failed with: %s' % str(job.errors))
-    sys.exit(-1)
-  logger.log('Uploaded {} rows into {}:{}.'.format(job.output_rows, dataset_id,
-                                                   table_id))
-
-def upload_to_storage(csv_file_path, project_id, bucket_id, destination):
-  # This is a workaround for
-  # https://github.com/bazelbuild/rules_python/issues/14
-  from google.cloud import storage
-
-  logger.log('Uploading data to Storage.')
-  client = storage.Client(project=project_id)
-  bucket = client.get_bucket(bucket_id)
-  blob = bucket.blob(destination)
-
-  blog.upload_from_filename(csv_file_path)
-
-  logger.log(
-      'Uploaded {} to {}/{}.'.format(csv_file_path, bucket_id, destination))
 

--- a/utils/output_handling.py
+++ b/utils/output_handling.py
@@ -63,7 +63,7 @@ def export_csv(data_directory, filename, data, project_source, platform):
   return csv_file_path
 
 
-def upload_csv(csv_file_path, project_id, dataset_id, table_id, location):
+def upload_to_bq(csv_file_path, project_id, dataset_id, table_id, location):
   """Uploads the csv file to BigQuery.
 
   Takes the configuration from config.json.
@@ -105,3 +105,19 @@ def upload_csv(csv_file_path, project_id, dataset_id, table_id, location):
     sys.exit(-1)
   logger.log('Uploaded {} rows into {}:{}.'.format(job.output_rows, dataset_id,
                                                    table_id))
+
+def upload_to_storage(csv_file_path, project_id, bucket_id, destination):
+  # This is a workaround for
+  # https://github.com/bazelbuild/rules_python/issues/14
+  from google.cloud import storage
+
+  logger.log('Uploading data to Storage.')
+  client = storage.Client(project=project_id)
+  bucket = client.get_bucket(bucket_id)
+  blob = bucket.blob(destination)
+
+  blog.upload_from_filename(csv_file_path)
+
+  logger.log(
+      'Uploaded {} to {}/{}.'.format(csv_file_path, bucket_id, destination))
+

--- a/utils/storage_upload.py
+++ b/utils/storage_upload.py
@@ -1,0 +1,41 @@
+# Copyright 2019 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Handles the uploading of results to Storage.
+"""
+import logger
+
+from google.cloud import storage
+
+def upload_to_storage(file_path, project_id, bucket_id, destination):
+  """Uploads the file to Storage.
+
+  Takes the configuration from GOOGLE_APPLICATION_CREDENTIALS.
+
+  Args:
+    file_path: the path to the file to be uploaded.
+    project_id: the GCP project id.
+    bucket_id: the Storage bucket.
+    destination: the path to the destination on the bucket.
+  """
+
+  logger.log('Uploading data to Storage.')
+  client = storage.Client(project=project_id)
+  bucket = client.get_bucket(bucket_id)
+  blob = bucket.blob(destination)
+
+  blog.upload_from_filename(file_path)
+
+  logger.log(
+      'Uploaded {} to {}/{}.'.format(file_path, bucket_id, destination))
+

--- a/utils/storage_upload.py
+++ b/utils/storage_upload.py
@@ -35,7 +35,7 @@ def upload_to_storage(file_path, project_id, bucket_id, destination):
   bucket = client.get_bucket(bucket_id)
   blob = bucket.blob(destination)
 
-  blog.upload_from_filename(file_path)
+  blob.upload_from_filename(file_path)
 
   logger.log(
       'Uploaded {} to {}/{}.'.format(file_path, bucket_id, destination))

--- a/utils/storage_upload.py
+++ b/utils/storage_upload.py
@@ -29,7 +29,6 @@ def upload_to_storage(file_path, project_id, bucket_id, destination):
     bucket_id: the Storage bucket.
     destination: the path to the destination on the bucket.
   """
-
   logger.log('Uploading data to Storage.')
   client = storage.Client(project=project_id)
   bucket = client.get_bucket(bucket_id)

--- a/utils/storage_upload.py
+++ b/utils/storage_upload.py
@@ -15,8 +15,6 @@
 """
 import logger
 
-from google.cloud import storage
-
 
 def upload_to_storage(file_path, project_id, bucket_id, destination):
   """Uploads the file to Storage.
@@ -29,6 +27,9 @@ def upload_to_storage(file_path, project_id, bucket_id, destination):
     bucket_id: the Storage bucket.
     destination: the path to the destination on the bucket.
   """
+  # This is a workaround for https://github.com/bazelbuild/rules_python/issues/14
+  from google.cloud import storage
+
   logger.log('Uploading data to Storage.')
   client = storage.Client(project=project_id)
   bucket = client.get_bucket(bucket_id)

--- a/utils/storage_upload.py
+++ b/utils/storage_upload.py
@@ -17,6 +17,7 @@ import logger
 
 from google.cloud import storage
 
+
 def upload_to_storage(file_path, project_id, bucket_id, destination):
   """Uploads the file to Storage.
 


### PR DESCRIPTION
**What this PR does and why we need it:**

This PR allows uploading CSV output to GCP Storage. This is part of the pipeline that generates daily reports for Bazel performance.

Nest step: upload collected JSON profiles to Storage.

**New changes / Issues that this PR fixes:**

- Refactored `output_handling` to 3 separate modules: `output_handling`, `bigquery_upload` and `storage_upload`. (This is a workaround for https://github.com/bazelbuild/rules_python/issues/14. Refactoring to separate modules & targets to prevent the `google` namespaces from clashing).
- Added a function to upload files to Storage.
- Added new flags: `--upload_to_storage` and `--csv_file_name`
- Renamed old flag: `--upload_data_to` -> `--upload_to_bigquery`

**Special notes for reviewer:**

None

**Does this require a change in the script's interface or the BigQuery's table structure?**

None
