### PR TITLE
[JSON profile] Add an option to only aggregate phase markers

### DIFF
--- a/utils/BUILD
+++ b/utils/BUILD
@@ -79,6 +79,7 @@ py_library(
 py_binary(
     name = "json_profiles_merger",
     srcs = ["json_profiles_merger.py"],
+    python_version = "PY2",
     deps = [
         ":utils",
         requirement("absl-py"),

--- a/utils/json_profiles_merger.py
+++ b/utils/json_profiles_merger.py
@@ -5,7 +5,7 @@ Collect median duration of events across these profiles.
 Usage:
   bazel run json_profiles_merger -- \
   --bazel_source=/usr/bin/bazel \
-  --project=https://github.com/bazelbuild/bazel \
+  --project_source=https://github.com/bazelbuild/bazel \
   --project_commit=2 \
   --output_path=/tmp/median_dur.csv \
   --upload_data_to=project-id:dataset-id:table-id:location \

--- a/utils/json_profiles_merger.py
+++ b/utils/json_profiles_merger.py
@@ -36,7 +36,9 @@ flags.DEFINE_string(
     'Uploads data to bigquery, requires output_path to be set. '
     'The details of the BigQuery table to upload results to specified in '
     'the form: <project_id>:<dataset_id>:<table_id>:<location>.')
-
+flags.DEFINE_boolean(
+    'only_phases', False,
+    'Whether to only include events from phase markers in the final output.')
 
 def main(argv):
   # Discard the first argument (the binary).
@@ -46,7 +48,8 @@ def main(argv):
       FLAGS.project_source,
       FLAGS.project_commit,
       input_profiles,
-      FLAGS.output_path)
+      FLAGS.output_path,
+      FLAGS.only_phases)
   if FLAGS.upload_data_to:
     project_id, dataset_id, table_id, location = FLAGS.upload_data_to.split(':')
     output_handling.upload_csv(

--- a/utils/json_profiles_merger_lib_test.py
+++ b/utils/json_profiles_merger_lib_test.py
@@ -95,6 +95,47 @@ class JsonProfilesMergerLibTest(unittest.TestCase):
             },
         }, accum_dict)
 
+
+  def test_accumulate_only_phase_marker(self):
+    event_list = [
+        {
+            'name': 'to_skip_no_dur',
+        },
+        {
+            'cat': 'build phase marker',
+            'name': 'phase1',
+            'ts': 1000
+        },
+        {
+            'cat': 'build phase marker',
+            'name': 'phase2',
+            'ts': 10000
+        },
+        {
+            'cat': 'fake_cat',
+            'name': 'fake_name',
+            'dur': 1,
+            'ts': 10001,
+            'non_dur': 'something'
+        },
+    ]
+
+    accum_dict = {}
+    lib._accumulate_event_duration(event_list, accum_dict, only_phases=True)
+    self.assertEqual(
+        {
+            'phase1': {
+                'cat': 'build phase marker',
+                'name': 'phase1',
+                'dur_list': [9.0]
+            },
+            'phase2': {
+                'cat': 'build phase marker',
+                'name': 'phase2',
+                'dur_list': [0.001]
+            },
+        }, accum_dict)
+
   def test_aggregate_from_accum_dict(self):
     accum_dict = {
         'fake_name': {


### PR DESCRIPTION
**What this PR does and why we need it:**

For our current purposes in the daily report, it suffices to only output the median duration of each build phase, instead of listing every single event. This PR adds a flag that allows us to do that.

**New changes / Issues that this PR fixes:**

- Add `--only_phases` to `json_profiles-merger`
- Switch the binary target to using python 2.

**Special notes for reviewer:**

None

**Does this require a change in the script's interface or the BigQuery's table structure?**

None
