### PR TITLE
Handle the case when exit status != 0

### DIFF
--- a/utils/bazel.py
+++ b/utils/bazel.py
@@ -66,7 +66,7 @@ class Bazel(object):
     exit_status = 0
 
     try:
-      command_result = subprocess.check_call(
+      subprocess.check_call(
         [self._bazel_binary_path, self._bazelrc_flag, command_name] + args,
         stdout=dev_null
       )

--- a/utils/bazel.py
+++ b/utils/bazel.py
@@ -63,10 +63,16 @@ class Bazel(object):
 
     before_times = self._get_times()
     dev_null = open(os.devnull, 'w')
-    process = subprocess.Popen(
+    exit_status = 0
+
+    try:
+      command_result = subprocess.check_call(
         [self._bazel_binary_path, self._bazelrc_flag, command_name] + args,
-        stdout=dev_null)
-    exit_status = process.wait()
+        stdout=dev_null
+      )
+    except subprocess.CalledProcessError as e:
+      exit_status = e.returncode
+      logger.log_error('Bazel command failed with exit code %s' % e.returncode)
 
     if command_name == 'shutdown':
       return None

--- a/utils/bazel_test.py
+++ b/utils/bazel_test.py
@@ -52,7 +52,7 @@ class BazelTest(unittest.TestCase):
   @mock.patch.object(bazel.Bazel, '_get_pid', return_value=123)
   @mock.patch.object(bazel.Bazel, '_get_heap_size')
   @mock.patch.object(bazel.Bazel, '_get_times')
-  @mock.patch.object(bazel.subprocess, 'Popen')
+  @mock.patch.object(bazel.subprocess, 'check_call', return_value=0)
   @mock.patch('datetime.datetime')
   def test_command(self, datetime_mock, subprocess_mock, get_times_mock,
                    get_heap_size_mock, _):
@@ -69,8 +69,6 @@ class BazelTest(unittest.TestCase):
         },
     ]
     get_heap_size_mock.side_effect = [700, 666, 668, 670, 667]
-    process_mock = subprocess_mock.return_value
-    process_mock.wait.return_value = 23
     datetime_mock.utcnow.return_value = 'fake_date'
 
     b = bazel.Bazel('foo', None)
@@ -80,14 +78,13 @@ class BazelTest(unittest.TestCase):
             'cpu': 26.8,
             'system': 2.0,
             'memory': 666,
-            'exit_status': 23,
+            'exit_status': 0,
             'started_at': 'fake_date'
         },
         b.command(
             command_name='build', args=['bar', 'zoo'], collect_memory=True))
     subprocess_mock.assert_called_with(
         ['foo', '--bazelrc=/dev/null', 'build', 'bar', 'zoo'], stdout=mock.ANY)
-
 
 if __name__ == '__main__':
   unittest.main()

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -18,6 +18,7 @@ from absl import logging
 _COLOR_TMPL = {
     'info': '\033[32m%s\033[0m',  # Green
     'warn': '\033[33m%s\033[0m',  # Yellow
+    'error': '\033[31m%s\033[0m',  # Red
 }
 
 
@@ -36,3 +37,8 @@ def log(text):
 def log_warn(text):
   """Logs a warning message using the logger singleton."""
   logging.warn(_maybe_colorize_text(text, 'warn'))
+
+def log_error(text):
+  """Logs an error message using the logger singleton."""
+  logging.error(_maybe_colorize_text(text, 'error'))
+

--- a/utils/values.py
+++ b/utils/values.py
@@ -14,7 +14,7 @@
 """"Stores a set of numeric values and offers statistical operations on them."""
 import numpy
 import scipy.stats
-
+import copy
 
 class Values(object):
   """Utility class to store numeric values.
@@ -68,3 +68,7 @@ class Values(object):
       return 1 - p
     else:
       return -1
+
+  def items(self):
+    return copy.copy(self._items)
+


### PR DESCRIPTION
**What this PR does and why we need it:**

This PR fixes #39 by adding an error log entry when the exit code of a bazel command returns a non-zero code. The actual _exclusion_ of the failed runs from the final dashboard/report will be done somewhere else (in the report generator itself).

Also fixes #33.

Update: The new summary table + exit-code message:
![Screenshot from 2019-07-01 15-15-31](https://user-images.githubusercontent.com/10117525/60439451-32acae00-9c13-11e9-8ab8-908344711741.png)

**New changes / Issues that this PR fixes:**

Issue #39.
