### PR TITLE
Exclude failed runs from summary table

### DIFF
--- a/utils/values.py
+++ b/utils/values.py
@@ -70,5 +70,17 @@ class Values(object):
       return -1
 
   def items(self):
+    """Returns a copy of the items.
+    """
     return copy.copy(self._items)
+
+  def exclude_from_indexes(self, indexes):
+    """Returns a copy of Values which excludes the items from certain indexes.
+    """
+    filtered = []
+    for i, value in enumerate(self._items):
+      if i not in indexes:
+        filtered.append(value)
+
+    return Values(filtered)
 


### PR DESCRIPTION
**What this PR does and why we need it:**

This PR excludes failed runs from the summary table and also clearly state which run failed with which exit code.

Screenshot:
![Screenshot from 2019-07-01 16-41-29](https://user-images.githubusercontent.com/10117525/60445544-b53b6a80-9c1f-11e9-9a5a-b4e202aedab0.png)

**New changes / Issues that this PR fixes:**

Fixes #49.
