### PR TITLE
Change bazel-bench root dir & add --sandbox_tmpfs_path=/tmp

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,27 @@ You can pass the pattern that selects the input profiles into the positional
 argument of the script, like in the above example
 (`/tmp/my_json_profiles_*.profile`).
 
+## Output Directory Layout
+
+By default, bazel-bench will store the measurement results and other required
+files (project clones, built binaries, ...) under the `~/.bazel-bench` directory.
+
+The layout is:
+
+```
+~/.bazel-bench/                         <= The root of bazel-bench's output dir.
+  bazel/                                <= Where bazel's repository is cloned.
+  bazel-bin/                            <= Where the built bazel binaries are stored.
+    fba9a2c87ee9589d72889caf082f1029/   <= The bazel commit hash.
+      bazel                             <= The actual bazel binary.
+  project-clones/                       <= Where the projects' repositories are cloned.
+    7ffd56a6e4cb724ea575aba15733d113/   <= Each project is stored under a project hash,
+                                           computed from its source.
+  out/                                  <= This is the default output root. But
+                                           the output root can also be set via --data_directory.
+```
+
+To clear the caches, simple `rm -rf` where necessary.
 
 ## Uploading to BigQuery & Storage
 

--- a/benchmark.py
+++ b/benchmark.py
@@ -523,6 +523,9 @@ def main(argv):
   # argv would be something like:
   # ['benchmark.py', 'build', '--nobuild', '//:all']
   bazel_args = argv[1:]
+  # This is a workaround for https://github.com/bazelbuild/bazel/issues/3236.
+  if sys.platform.startswith('linux'):
+    bazel_args.append('--sandbox_tmpfs_path=/tmp')
 
   # Building Bazel binaries
   bazel_binaries = []

--- a/benchmark.py
+++ b/benchmark.py
@@ -35,27 +35,18 @@ from absl import flags
 from utils.values import Values
 from utils.bazel import Bazel
 
-# TMP has different values, depending on the platform.
-TMP = tempfile.gettempdir()
-
-
-def _platform_path_str(posix_path):
-  """Converts the path to the appropriate format for platform."""
-  if os.name == 'nt':
-    return posix_path.replace('/', '\\')
-  return posix_path
-
+# BB_ROOT has different values, depending on the platform.
+BB_ROOT = os.path.join(os.path.expanduser('~'), '.bazel-bench')
 
 # The path to the cloned bazelbuild/bazel repo.
-BAZEL_CLONE_PATH = _platform_path_str('%s/.bazel-bench/bazel' % TMP)
+BAZEL_CLONE_PATH = os.path.join(BB_ROOT, 'bazel')
 # The path to the clone of the project to be built with Bazel.
-PROJECT_CLONE_BASE_PATH = _platform_path_str('%s/.bazel-bench/project-clones' %
-                                             TMP)
+PROJECT_CLONE_BASE_PATH = os.path.join(BB_ROOT, 'project-clones')
 BAZEL_GITHUB_URL = 'https://github.com/bazelbuild/bazel.git'
 # The path to the directory that stores the bazel binaries.
-BAZEL_BINARY_BASE_PATH = _platform_path_str('%s/.bazel-bench/bazel-bin' % TMP)
+BAZEL_BINARY_BASE_PATH = os.path.join(BB_ROOT, 'bazel-bin')
 # The path to the directory that stores the output csv (If required).
-DEFAULT_OUT_BASE_PATH = _platform_path_str('%s/.bazel-bench/out' % TMP)
+DEFAULT_OUT_BASE_PATH = os.path.join(BB_ROOT, 'out')
 # The default name of the aggr json profile.
 DEFAULT_AGGR_JSON_PROFILE_FILENAME = 'aggr_json_profiles.csv'
 
@@ -523,9 +514,6 @@ def _flag_checks():
   if FLAGS.aggregate_json_profiles and not FLAGS.collect_json_profile:
     raise ValueError('--aggregate_json_profiles requires '
                      '--collect_json_profile to be set.')
-  if FLAGS.collect_json_profile and not FLAGS.data_directory:
-    raise ValueError('--collect_json_profile requires '
-                     '--data_directory to be set.')
 
 
 def main(argv):

--- a/benchmark_test.py
+++ b/benchmark_test.py
@@ -167,6 +167,7 @@ class BenchmarkFunctionTests(absltest.TestCase):
   @mock.patch.object(benchmark.args_parser, 'parse_bazel_args_from_build_event')
   def test_run_benchmark_prefetch(self, args_parser_mock, _):
     args_parser_mock.return_value = ('build', ['//:all'], [])
+    benchmark.DEFAULT_OUT_BASE_PATH = 'some_out_path'
     with mock.patch.object(sys, 'stderr', new=mock_stdio_type()) as mock_stderr:
       benchmark._run_benchmark(
           'bazel_binary_path',
@@ -180,8 +181,8 @@ class BenchmarkFunctionTests(absltest.TestCase):
 
     self.assertEqual(
         ''.join([
-            'Pre-fetching external dependencies & exporting build event json to /tmp/.bazel-bench/out/build_env.json...',
-            'Executing Bazel command: bazel build --nostamp --noshow_progress --color=no //:all --build_event_json_file=/tmp/.bazel-bench/out/build_env.json',
+            'Pre-fetching external dependencies & exporting build event json to some_out_path/build_env.json...',
+            'Executing Bazel command: bazel build --nostamp --noshow_progress --color=no //:all --build_event_json_file=some_out_path/build_env.json',
             'Executing Bazel command: bazel clean --color=no',
             'Executing Bazel command: bazel shutdown ',
             'Starting benchmark run 1/2:',
@@ -198,6 +199,7 @@ class BenchmarkFunctionTests(absltest.TestCase):
   @mock.patch.object(benchmark.args_parser, 'parse_bazel_args_from_build_event')
   def test_run_benchmark_collect_json_profile(self, args_parser_mock, _):
     args_parser_mock.return_value = ('build', ['//:all'], [])
+    benchmark.DEFAULT_OUT_BASE_PATH = 'some_out_path'
     with mock.patch.object(sys, 'stderr', new=mock_stdio_type()) as mock_stderr:
       benchmark._run_benchmark(
           'bazel_binary_path',
@@ -215,8 +217,8 @@ class BenchmarkFunctionTests(absltest.TestCase):
 
     self.assertEqual(
         ''.join([
-            'Pre-fetching external dependencies & exporting build event json to /tmp/.bazel-bench/out/build_env.json...',
-            'Executing Bazel command: bazel build --nostamp --noshow_progress --color=no //:all --build_event_json_file=/tmp/.bazel-bench/out/build_env.json',
+            'Pre-fetching external dependencies & exporting build event json to some_out_path/build_env.json...',
+            'Executing Bazel command: bazel build --nostamp --noshow_progress --color=no //:all --build_event_json_file=some_out_path/build_env.json',
             'Executing Bazel command: bazel clean --color=no',
             'Executing Bazel command: bazel shutdown ',
             'Starting benchmark run 1/2:',


### PR DESCRIPTION
**What this PR does and why we need it:**

Bazel-bench runs would sometime fail on Linux environments due to a race condition. This is tracked at https://github.com/bazelbuild/bazel/issues/3236.

As a workaround, we need to apply `--sandbox_tmpfs_path=/tmp` to our runs on Linux. This PR injects that flag to the list of args if `os.platform.startswith('linux')`.

This PR also moves the root of bazel-bench's output directory to `~/.bazel-bench/` instead of `/tmp/.bazel-bench/`, so that the flag `sandbox_tmpfs_path` (whose value is hardcoded to `/tmp/`) works.

**New changes / Issues that this PR fixes:**

Fixes #42.

