### PR TITLE
Add Google Analytics to the report

### DIFF
--- a/report/generate_report.py
+++ b/report/generate_report.py
@@ -282,6 +282,15 @@ def _full_report(project, project_source, date, command, graph_components, raw_f
   return """
 <html>
   <head>
+  <!-- Global site tag (gtag.js) - Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-143284743-1"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){{dataLayer.push(arguments);}}
+    gtag('js', new Date());
+
+    gtag('config', 'UA-143284743-1');
+  </script>
   <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
   <script type="text/javascript">
     google.charts.load("current", {{ packages:["corechart"] }});


### PR DESCRIPTION
**What this PR does and why we need it:**

With GA, we can collect data on report usage.

