### PR TITLE
Add an option to specify binary directory

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -462,6 +462,8 @@ flags.DEFINE_string('bazel_source',
                     'https://github.com/bazelbuild/bazel.git',
                     'Either a path to the local Bazel repo or a https url to ' \
                     'a GitHub repository.')
+flags.DEFINE_string('bazel_bin_dir', None,
+                    'The directory to store the bazel binaries from each commit.')
 
 # Flags for the project to be built.
 flags.DEFINE_string('project_source', None,
@@ -556,10 +558,12 @@ def main(argv):
   # We use the start time as a unique identifier of this bazel-bench run.
   bazel_bench_uid = datetime.datetime.utcnow().strftime("%Y%m%d%H%M%S")
 
+  bazel_bin_base_path = FLAGS.bazel_bin_dir or BAZEL_BINARY_BASE_PATH
+
   for bazel_commit in bazel_commits:
     for project_commit in project_commits:
       bazel_binary_path = _build_bazel_binary(bazel_commit, bazel_clone_repo,
-                                              BAZEL_BINARY_BASE_PATH)
+                                              bazel_bin_base_path)
       project_clone_repo.git.checkout('-f', project_commit)
 
       results, args = _run_benchmark(


### PR DESCRIPTION
**What this PR does and why we need it:**

This PR adds a new option that specifies the directory to store the built bazel binaries.

This is a step towards #59.