### PR TITLE
Add min/max/count to json profiles merger

### DIFF
--- a/utils/json_profiles_merger_lib.py
+++ b/utils/json_profiles_merger_lib.py
@@ -1,5 +1,7 @@
 """A library that holds the bulk of the logic for merging JSON profiles.
 Collect duration statistics of events across these profiles.
+
+Duration is measured in milliseconds.
 """
 from __future__ import division
 
@@ -106,13 +108,14 @@ def _accumulate_event_duration(event_list, accum_dict, only_phases=False):
           'cat': 'build phase marker',
           'dur_list': []
       }
-    current_phase_duration_millis = (next_ts - ts) / 1000
+    current_phase_duration_millis = (next_ts - ts) / 1000 # Convert from microseconds to milliseconds
     accum_dict[marker]['dur_list'].append(current_phase_duration_millis)
 
 
 def _aggregate_from_accum_dict(accum_dict):
   """Aggregate the result from the accummulated dict.
   Calculate statistics of the durations and counts for each event.
+  All measurements of time should be in milliseconds.
   Args:
     accum_dict: the dict to be filled up with a mapping of the following format:
       { <name>: { name: ..., cat: ..., dur_list: [...]}, ...}

--- a/utils/json_profiles_merger_lib.py
+++ b/utils/json_profiles_merger_lib.py
@@ -1,5 +1,5 @@
 """A library that holds the bulk of the logic for merging JSON profiles.
-Collect median duration of events across these profiles.
+Collect duration statistics of events across these profiles.
 """
 from __future__ import division
 
@@ -27,7 +27,8 @@ def write_to_csv(
     bazel_source, project_source, project_commit, event_list, output_csv_path):
   """Writes the event_list to output_csv_path.
   event_list format:
-  [{'cat': <string>, 'name': <string>, 'dur': <int>}, ...]
+  [{'cat': <string>, 'name': <string>, 'min': <int>,
+    'median': <int>, 'max': <int>, 'count': <int>}, ...]
   Args:
     bazel_source: the bazel commit or path to the bazel binary from which these
       JSON profiles were collected.
@@ -45,12 +46,13 @@ def write_to_csv(
     csv_writer = csv.writer(csv_file)
     csv_writer.writerow(
         ['bazel_source', 'project_source', 'project_commit',
-         'cat', 'name', 'dur'])
+         'cat', 'name', 'min', 'median', 'max', 'count'])
 
     for event in event_list:
       csv_writer.writerow(
           [bazel_source, project_source, project_commit,
-           event['cat'], event['name'], event['dur']])
+           event['cat'], event['name'], event['min'], event['median'],
+           event['max'], event['count']])
 
 
 def _accumulate_event_duration(event_list, accum_dict, only_phases=False):
@@ -110,20 +112,23 @@ def _accumulate_event_duration(event_list, accum_dict, only_phases=False):
 
 def _aggregate_from_accum_dict(accum_dict):
   """Aggregate the result from the accummulated dict.
-  Calculate the median of the durations for each event.
+  Calculate statistics of the durations and counts for each event.
   Args:
     accum_dict: the dict to be filled up with a mapping of the following format:
       { <name>: { name: ..., cat: ..., dur_list: [...]}, ...}
   Returns:
     A list of the following format:
-      [{ name: ..., cat: ..., dur: ... }]
+      [{ name: ..., cat: ..., median: ..., min: ..., median: ..., max: ..., count: ... }]
   """
   result = []
   for obj in accum_dict.values():
     result.append({
         'name': obj['name'],
         'cat': obj['cat'],
-        'dur': _median(obj['dur_list'])
+        'median': _median(obj['dur_list']),
+        'min': min(obj['dur_list']),
+        'max': max(obj['dur_list']),
+        'count': len(obj['dur_list'])
     })
   return result
 
@@ -136,7 +141,7 @@ def aggregate_data(input_profiles, only_phases=False):
     input_profiles: a list of paths to .profile or .profile.gz files.
     only_phases: only output entries from phase markers.
   Returns:
-    The list of objects which contain the info about cat, name and median
+    The list of objects which contain the info about cat, name and statistics on the
     duration of events.
   """
   # A map from event name to an object which accumulates the durations.

--- a/utils/json_profiles_merger_lib_test.py
+++ b/utils/json_profiles_merger_lib_test.py
@@ -148,7 +148,10 @@ class JsonProfilesMergerLibTest(unittest.TestCase):
     self.assertEqual([{
         'cat': 'fake_cat',
         'name': 'fake_name',
-        'dur': 2.0
+        'median': 2.0,
+        'min': 1,
+        'max': 3,
+        'count': 2
     }], lib._aggregate_from_accum_dict(accum_dict))
 
 


### PR DESCRIPTION
**What this PR does and why we need it:**

This adds additional information to the `json_profile_merger` tool to enable further analysis of action durations.

**New changes / Issues that this PR fixes:**

Adds new columns including `min`, `max`, and `count` whilst 'dur' is renamed to 'median'

**Does this require a change in the script's interface or the BigQuery's table structure?**

This will require changes towards the BigQuery table structure. 
