### PR TITLE
Unify SHA digests length

### DIFF
--- a/benchmark_test.py
+++ b/benchmark_test.py
@@ -68,6 +68,7 @@ class BenchmarkFunctionTests(absltest.TestCase):
       mock_C = mock.MagicMock()
       mock_C.hexsha = 'C'
       mock_repo.iter_commits.return_value = [mock_C, mock_B, mock_A]
+      mock_repo.git.rev_parse.side_effect = lambda x: x
       result = benchmark._get_commits_topological(['B', 'A'], mock_repo,
                                                   'flag_name')
 


### PR DESCRIPTION
**What this PR does and why we need it:**

This PR adds the logic to handle the case when an input commit digest is short (e.g. the typical 7-char digest).
