### PR TITLE
Add error for no parameters on jsonprofilemerger

### DIFF
--- a/utils/json_profiles_merger.py
+++ b/utils/json_profiles_merger.py
@@ -42,6 +42,9 @@ def main(argv):
   # Discard the first argument (the binary).
   input_profiles = argv[1:]
 
+  if not input_profiles:
+    raise ValueError('At least one profile must be provided!')
+
   aggregated_data = lib.aggregate_data(
       input_profiles,
       FLAGS.only_phases)

--- a/utils/json_profiles_merger.py
+++ b/utils/json_profiles_merger.py
@@ -18,6 +18,7 @@ import output_handling
 
 FLAGS = flags.FLAGS
 flags.DEFINE_string('output_path', None, 'The path to the output file.')
+flags.mark_flag_as_required('output_path')
 flags.DEFINE_string(
     'bazel_source', None,
     ('(Optional) The bazel commit or path to the bazel binary from which these'

--- a/utils/json_profiles_merger_lib.py
+++ b/utils/json_profiles_merger_lib.py
@@ -41,7 +41,7 @@ def write_to_csv(
     output_csv_path: a path to the output CSV file.
   """
   output_dir = os.path.dirname(output_csv_path)
-  if not os.path.exists(output_dir):
+  if output_dir and not os.path.exists(output_dir):
     os.makedirs(output_dir)
 
   with open(output_csv_path, 'w') as csv_file:


### PR DESCRIPTION
**What this PR does and why we need it:**

It might save someone some time looking at the stack trace.

**New changes / Issues that this PR fixes:**

jsonprofilemerger did not provide any check for an empty parameter list, but errored further into execution when none were provided.

**Special notes for reviewer:**

The new output is still not as clean as I'd like, but I wasn't sure the best way to handle reporting this to the user.

Example new output:
```
Traceback (most recent call last):
  File "/home/user/.cache/bazel/_bazel_user/c0fe45a85c85ea43d6d62cbc57b2f48c/execroot/__main__/bazel-out/k8-py2-fastbuild/bin/utils/json_profiles_merger.runfiles/__main__/utils/json_profiles_merger.py", line 70, in <module>
    app.run(main)
  File "/home/user/.cache/bazel/_bazel_user/c0fe45a85c85ea43d6d62cbc57b2f48c/execroot/__main__/bazel-out/k8-py2-fastbuild/bin/utils/json_profiles_merger.runfiles/third_party_pypi__absl_py_0_7_0/absl/app.py", line 300, in run
    _run_main(main, args)
  File "/home/user/.cache/bazel/_bazel_user/c0fe45a85c85ea43d6d62cbc57b2f48c/execroot/__main__/bazel-out/k8-py2-fastbuild/bin/utils/json_profiles_merger.runfiles/third_party_pypi__absl_py_0_7_0/absl/app.py", line 251, in _run_main
    sys.exit(main(argv))
  File "/home/user/.cache/bazel/_bazel_user/c0fe45a85c85ea43d6d62cbc57b2f48c/execroot/__main__/bazel-out/k8-py2-fastbuild/bin/utils/json_profiles_merger.runfiles/__main__/utils/json_profiles_merger.py", line 46, in main
    raise RuntimeError("At least one profile must be provided!")
RuntimeError: At least one profile must be provided!
```

**Does this require a change in the script's interface or the BigQuery's table structure?**

No
