### PR TITLE
Added project_label column

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -487,6 +487,8 @@ flags.DEFINE_string('bazel_bin_dir', None,
                     'The directory to store the bazel binaries from each commit.')
 
 # Flags for the project to be built.
+flags.DEFINE_string('project_label', None,
+                    'The label of the project. Only relevant in the daily performance report.')
 flags.DEFINE_string('project_source', None,
                     'Either a path to the local git project to be built or ' \
                     'a https url to a GitHub repository.')
@@ -634,7 +636,8 @@ def main(argv):
         csv_file_name,
         csv_data,
         FLAGS.project_source,
-        FLAGS.platform)
+        FLAGS.platform,
+        FLAGS.project_label)
     output_handling.export_file(data_directory, txt_file_name, summary_text)
 
     if FLAGS.aggregate_json_profiles:

--- a/utils/output_handling.py
+++ b/utils/output_handling.py
@@ -19,7 +19,7 @@ import getpass
 import logger
 
 
-def export_csv(data_directory, filename, data, project_source, platform):
+def export_csv(data_directory, filename, data, project_source, platform, project_label):
   """Exports the content of data to a csv file in data_directory
 
   Args:
@@ -29,6 +29,8 @@ def export_csv(data_directory, filename, data, project_source, platform):
     project_source: either a path to the local git project to be built or a
       https url to a GitHub repository.
     platform: the platform on which benchmarking was run.
+    project_label: the label to identify the project. Only relevant for the
+      daily performance report.
 
   Returns:
     The path to the newly created csv file.
@@ -43,7 +45,7 @@ def export_csv(data_directory, filename, data, project_source, platform):
     username = getpass.getuser()
     csv_writer = csv.writer(csv_file)
     csv_writer.writerow([
-        'project_source', 'project_commit', 'bazel_commit', 'run', 'cpu',
+        'project_label', 'project_source', 'project_commit', 'bazel_commit', 'run', 'cpu',
         'wall', 'system', 'memory', 'command', 'expressions', 'hostname',
         'username', 'options', 'exit_status', 'started_at', 'platform'
     ])
@@ -52,7 +54,7 @@ def export_csv(data_directory, filename, data, project_source, platform):
       command, expressions, options = results_and_args['args']
       for idx, run in enumerate(results_and_args['results'], start=1):
         csv_writer.writerow([
-            project_source, project_commit, bazel_commit, idx, run['cpu'],
+            project_label, project_source, project_commit, bazel_commit, idx, run['cpu'],
             run['wall'], run['system'], run['memory'], command, expressions,
             hostname, username, options, run['exit_status'], run['started_at'],
             platform


### PR DESCRIPTION
**What this PR does and why we need it:**

This PR adds a new column `project_label` to the CSV output. We used to use `project_source` to be the identification of each project, but sometimes we want to benchmark different aspects of a project e.g. `tf-python` or `tf-cpp`, so a `project_label` field is necessary.

**Does this require a change in the script's interface or the BigQuery's table structure?**

Yes.
