### PR TITLE
Use Py3

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -5,9 +5,8 @@ load("@bazel_tools//tools/python:toolchain.bzl", "py_runtime_pair")
 py_binary(
     name = "benchmark",
     srcs = ["benchmark.py"],
-    python_version = "PY2",
     deps = [
-        "//utils",
+        "//utils:utils",
         requirement("absl-py"),
         requirement("GitPython"),
         requirement("gitdb2"),

--- a/BUILD
+++ b/BUILD
@@ -16,10 +16,9 @@ py_binary(
 py_test(
     name = "benchmark_test",
     srcs = ["benchmark_test.py"],
-    python_version = "PY2",
     deps = [
         ":benchmark",
-        "//testutils",
+        "//testutils:testutils",
         requirement("mock"),
     ],
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -7,13 +7,13 @@ git_repository(
 )
 
 # Only needed for PIP support:
-load("@rules_python//python:pip.bzl", "pip_repositories", "pip_import")
+load("@rules_python//python:pip.bzl", "pip_repositories", "pip3_import")
 
 pip_repositories()
 
 # This rule translates the specified requirements.txt into
 # @my_deps//:requirements.bzl, which itself exposes a pip_install method.
-pip_import(
+pip3_import(
     name = "third_party",
     requirements = "//third_party:requirements.txt",
 )

--- a/benchmark.py
+++ b/benchmark.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import print_function
 
 import csv
 import collections
@@ -53,7 +52,7 @@ DEFAULT_AGGR_JSON_PROFILE_FILENAME = 'aggr_json_profiles.csv'
 
 def _get_clone_subdir(project_source):
   """Calculates a hexdigest of project_source to serve as a unique subdir name."""
-  return hashlib.md5(project_source).hexdigest()
+  return hashlib.md5(project_source.encode('utf-8')).hexdigest()
 
 
 def _exec_command(args, shell=False, fail_if_nonzero=True, cwd=None):

--- a/benchmark_test.py
+++ b/benchmark_test.py
@@ -114,9 +114,9 @@ class BenchmarkFunctionTests(absltest.TestCase):
     self.assertEqual(
         ''.join([
             'Building Bazel binary at commit commit',
-            "['bazel', 'build', '//src:bazel']",
+            'bazel build //src:bazel',
             'Copying bazel binary to outroot/commit/bazel',
-            "['chmod', '+x', 'outroot/commit/bazel']"
+            'chmod +x outroot/commit/bazel'
         ]), mock_stderr.getvalue())
 
   def test_single_run(self):
@@ -259,7 +259,7 @@ class BenchmarkFlagsTest(absltest.TestCase):
       benchmark._flag_checks()
     value_err = context.exception
     self.assertEqual(
-        value_err.message,
+        str(value_err),
         'Either --bazel_commits or --project_commits should be a single element.'
     )
 

--- a/testutils/fakes.py
+++ b/testutils/fakes.py
@@ -22,7 +22,7 @@ def fake_log(text):
 
 def fake_exec_command(args, shell=False, fail_if_nonzero=True, cwd=None):
   """Fakes the _exec_command function."""
-  fake_log(args)
+  fake_log(' '.join(args))
 
 
 class FakeBazel(object):

--- a/third_party/requirements.txt
+++ b/third_party/requirements.txt
@@ -15,7 +15,7 @@ google-resumable-media==0.3.2
 googleapis-common-protos==1.6.0
 idna==2.8
 mock==2.0.0
-numpy==1.16.4
+numpy==1.16.6
 pbr==5.1.3
 protobuf==3.6.1
 psutil==5.5.1

--- a/utils/BUILD
+++ b/utils/BUILD
@@ -56,7 +56,6 @@ py_library(
 py_binary(
     name = "bigquery_upload",
     srcs = ["bigquery_upload.py"],
-    python_version = "PY2",
     deps = [
         # This is a workaround for https://github.com/bazelbuild/rules_python/issues/14,
         # google-cloud-bigquery must be listed first.
@@ -70,7 +69,6 @@ py_binary(
 py_binary(
     name = "storage_upload",
     srcs = ["storage_upload.py"],
-    python_version = "PY2",
     deps = [
         # This is a workaround for https://github.com/bazelbuild/rules_python/issues/14,
         # google-cloud-storage must be listed first.
@@ -83,7 +81,6 @@ py_binary(
 py_binary(
     name = "json_profiles_merger",
     srcs = ["json_profiles_merger.py"],
-    python_version = "PY2",
     deps = [
         ":utils",
         requirement("absl-py"),
@@ -94,7 +91,6 @@ py_test(
     name = "bazel_args_parser_test",
     size = "small",
     srcs = ["bazel_args_parser_test.py"],
-    python_version = "PY2",
     deps = [
         ":utils",
         requirement("mock"),
@@ -105,7 +101,6 @@ py_test(
     name = "bazel_test",
     size = "small",
     srcs = ["bazel_test.py"],
-    python_version = "PY2",
     deps = [
         ":utils",
         requirement("mock"),
@@ -116,7 +111,6 @@ py_test(
     name = "values_test",
     size = "small",
     srcs = ["values_test.py"],
-    python_version = "PY2",
     deps = [
         ":utils",
         requirement("mock"),
@@ -127,7 +121,6 @@ py_test(
     name = "json_profiles_merger_lib_test",
     size = "small",
     srcs = ["json_profiles_merger_lib_test.py"],
-    python_version = "PY2",
     deps = [
         ":utils",
         requirement("mock"),
@@ -138,7 +131,6 @@ py_test(
     name = "benchmark_config_test",
     size = "small",
     srcs = ["benchmark_config_test.py"],
-    python_version = "PY2",
     deps = [
         ":utils",
     ],

--- a/utils/bazel.py
+++ b/utils/bazel.py
@@ -16,8 +16,8 @@ import subprocess
 import os
 import time
 import psutil
-import logger
 import datetime
+import utils.logger as logger
 
 
 class Bazel(object):

--- a/utils/bazel_args_parser.py
+++ b/utils/bazel_args_parser.py
@@ -22,7 +22,7 @@ parse_bazel_args_from_canonical_str.
 """
 
 import json
-import logger
+import utils.logger as logger
 
 
 def _to_str_list(unicode_str_list):

--- a/utils/bazel_args_parser_test.py
+++ b/utils/bazel_args_parser_test.py
@@ -97,7 +97,7 @@ class BazelArgsParserTest(unittest.TestCase):
     self.assertEqual(options, ["--option1", "--option2=xyz"])
 
   def test_parse_bazel_args_from_build_event(self):
-    fake_file_content = "\n".join([json.dumps(event) for event in fake_events])
+    fake_file_content = ("\n".join([json.dumps(event) for event in fake_events])).encode("utf-8")
     with tempfile.NamedTemporaryFile() as bep_json:
       bep_json.write(fake_file_content)
       bep_json.flush()

--- a/utils/bigquery_upload.py
+++ b/utils/bigquery_upload.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 """Handles the uploading of result CSV to BigQuery.
 """
-import logger
 import re
 import sys
+import utils.logger as logger
 
 from absl import app
 from absl import flags

--- a/utils/output_handling.py
+++ b/utils/output_handling.py
@@ -16,7 +16,7 @@ import csv
 import socket
 import getpass
 
-import logger
+import utils.logger as logger
 
 
 def export_csv(data_directory, filename, data, project_source, platform, project_label):

--- a/utils/storage_upload.py
+++ b/utils/storage_upload.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 """Handles the uploading of results to Storage.
 """
-import logger
 import os
 import re
+import utils.logger as logger
 
 from absl import app
 from absl import flags


### PR DESCRIPTION
**What this PR does and why we need it:**

With the new changes in rules_python, we can now use pip3_import to migrate our targets to be py3-compatible.

Fixes https://github.com/bazelbuild/bazel-bench/issues/36.
