### PR TITLE
Separate built binaries by platforms.

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -143,7 +143,7 @@ def _setup_project_repo(repo_path, project_source):
   return repo
 
 
-def _build_bazel_binary(commit, repo, outroot):
+def _build_bazel_binary(commit, repo, outroot, platform):
   """Builds bazel at the specified commit and copy the output binary to outroot.
 
   If the binary for this commit already exists at the destination path, simply
@@ -153,11 +153,12 @@ def _build_bazel_binary(commit, repo, outroot):
     commit: the Bazel commit SHA.
     repo: the git.Repo instance of the Bazel clone.
     outroot: the directory inwhich the resulting binary is copied to.
+    platform: the platform on which to build this binary.
 
   Returns:
     The path to the resulting binary (copied to outroot).
   """
-  outroot_for_commit = '%s/%s' % (outroot, commit)
+  outroot_for_commit = '%s/%s/%s' % (outroot, platform, commit)
   destination = '%s/bazel' % outroot_for_commit
   if os.path.exists(destination):
     logger.log('Binary exists at %s, reusing...' % destination)
@@ -587,7 +588,7 @@ def main(argv):
 
   for bazel_commit in bazel_commits:
     bazel_bin_path = _build_bazel_binary(
-        bazel_commit, bazel_clone_repo, bazel_bin_base_path)
+        bazel_commit, bazel_clone_repo, bazel_bin_base_path, FLAGS.platform)
     bazel_bin_identifiers.append((bazel_bin_path, bazel_commit))
 
   for bazel_bin_path in bazel_binaries:

--- a/benchmark.py
+++ b/benchmark.py
@@ -143,7 +143,7 @@ def _setup_project_repo(repo_path, project_source):
   return repo
 
 
-def _build_bazel_binary(commit, repo, outroot, platform):
+def _build_bazel_binary(commit, repo, outroot, platform=None):
   """Builds bazel at the specified commit and copy the output binary to outroot.
 
   If the binary for this commit already exists at the destination path, simply
@@ -158,7 +158,8 @@ def _build_bazel_binary(commit, repo, outroot, platform):
   Returns:
     The path to the resulting binary (copied to outroot).
   """
-  outroot_for_commit = '%s/%s/%s' % (outroot, platform, commit)
+  outroot_for_commit = '%s/%s/%s' % (
+    outroot, platform, commit) if platform else '%s/%s' % (outroot, commit)
   destination = '%s/bazel' % outroot_for_commit
   if os.path.exists(destination):
     logger.log('Binary exists at %s, reusing...' % destination)

--- a/benchmark_test.py
+++ b/benchmark_test.py
@@ -93,8 +93,8 @@ class BenchmarkFunctionTests(absltest.TestCase):
   def test_build_bazel_binary_exists(self, unused_chdir_mock,
                                      unused_exists_mock):
     with mock.patch.object(sys, 'stderr', new=mock_stdio_type()) as mock_stderr:
-      benchmark._build_bazel_binary('commit', 'repo_path', 'outroot', 'platform')
-    self.assertEqual('Binary exists at outroot/platform/commit/bazel, reusing...',
+      benchmark._build_bazel_binary('commit', 'repo_path', 'outroot')
+    self.assertEqual('Binary exists at outroot/commit/bazel, reusing...',
                      mock_stderr.getvalue())
 
   @mock.patch.object(benchmark.os.path, 'exists', return_value=False)
@@ -108,15 +108,15 @@ class BenchmarkFunctionTests(absltest.TestCase):
     with mock.patch.object(sys, 'stderr', new=mock_stdio_type()) as mock_stderr, \
       mock.patch('benchmark.git.Repo') as mock_repo_class:
       mock_repo = mock_repo_class.return_value
-      benchmark._build_bazel_binary('commit', mock_repo, 'outroot', 'platform')
+      benchmark._build_bazel_binary('commit', mock_repo, 'outroot')
 
     mock_repo.git.checkout.assert_called_once_with('-f', 'commit')
     self.assertEqual(
         ''.join([
             'Building Bazel binary at commit commit',
             'bazel build //src:bazel',
-            'Copying bazel binary to outroot/platform/commit/bazel',
-            'chmod +x outroot/platform/commit/bazel'
+            'Copying bazel binary to outroot/commit/bazel',
+            'chmod +x outroot/commit/bazel'
         ]), mock_stderr.getvalue())
 
   def test_single_run(self):

--- a/benchmark_test.py
+++ b/benchmark_test.py
@@ -93,8 +93,8 @@ class BenchmarkFunctionTests(absltest.TestCase):
   def test_build_bazel_binary_exists(self, unused_chdir_mock,
                                      unused_exists_mock):
     with mock.patch.object(sys, 'stderr', new=mock_stdio_type()) as mock_stderr:
-      benchmark._build_bazel_binary('commit', 'repo_path', 'outroot')
-    self.assertEqual('Binary exists at outroot/commit/bazel, reusing...',
+      benchmark._build_bazel_binary('commit', 'repo_path', 'outroot', 'platform')
+    self.assertEqual('Binary exists at outroot/platform/commit/bazel, reusing...',
                      mock_stderr.getvalue())
 
   @mock.patch.object(benchmark.os.path, 'exists', return_value=False)
@@ -108,15 +108,15 @@ class BenchmarkFunctionTests(absltest.TestCase):
     with mock.patch.object(sys, 'stderr', new=mock_stdio_type()) as mock_stderr, \
       mock.patch('benchmark.git.Repo') as mock_repo_class:
       mock_repo = mock_repo_class.return_value
-      benchmark._build_bazel_binary('commit', mock_repo, 'outroot')
+      benchmark._build_bazel_binary('commit', mock_repo, 'outroot', 'platform')
 
     mock_repo.git.checkout.assert_called_once_with('-f', 'commit')
     self.assertEqual(
         ''.join([
             'Building Bazel binary at commit commit',
             'bazel build //src:bazel',
-            'Copying bazel binary to outroot/commit/bazel',
-            'chmod +x outroot/commit/bazel'
+            'Copying bazel binary to outroot/platform/commit/bazel',
+            'chmod +x outroot/platform/commit/bazel'
         ]), mock_stderr.getvalue())
 
   def test_single_run(self):


### PR DESCRIPTION
**What this PR does and why we need it:**

Not all binaries work on all platforms, so when a platform is specified, we should use it to classify built binaries. This is especially relevant for our pipeline on BuildKite.