### PR TITLE
Bump numpy and scipy versions

### DIFF
--- a/.bazelci/postsubmit.yml
+++ b/.bazelci/postsubmit.yml
@@ -1,15 +1,5 @@
 ---
 tasks:
-  ubuntu1604:
-    include_json_profile:
-      - build
-      - test
-    shell_commands:
-    - pip3 install -r third_party/requirements.txt
-    build_targets:
-      - "..."
-    test_targets:
-      - "..."
   ubuntu1804:
     include_json_profile:
       - build

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,12 +1,5 @@
 ---
 tasks:
-  ubuntu1604:
-    shell_commands:
-    - pip3 install -r third_party/requirements.txt
-    build_targets:
-      - "..."
-    test_targets:
-      - "..."
   ubuntu1804:
     shell_commands:
     - pip3 install -r third_party/requirements.txt

--- a/third_party/requirements.txt
+++ b/third_party/requirements.txt
@@ -15,7 +15,7 @@ google-resumable-media==0.3.2
 googleapis-common-protos==1.6.0
 idna==2.8
 mock==2.0.0
-numpy==1.16.6
+numpy==1.18.5
 pbr==5.1.3
 protobuf==3.6.1
 psutil==5.6.6
@@ -24,7 +24,7 @@ pyasn1-modules==0.2.4
 pytz==2018.9
 requests==2.21.0
 rsa==4.0
-scipy==1.2.1
+scipy==1.5.0
 six==1.12.0
 urllib3==1.24.2
 PyYAML==3.13

--- a/utils/values_test.py
+++ b/utils/values_test.py
@@ -59,8 +59,8 @@ class ValuesTest(unittest.TestCase):
     self.assertEqual(0, values.pval(identical_list))
 
   def test_pval_significant(self):
-    values = Values([1, 1, 1])
-    self.assertAlmostEqual(0.900, values.pval([10, 10, 10]), places=3)
+    values = Values([1, 1, 1, 1, 1])
+    self.assertAlmostEqual(0.992, values.pval([10, 10, 10, 10, 10]), places=3)
 
 
 if __name__ == '__main__':

--- a/utils/values_test.py
+++ b/utils/values_test.py
@@ -60,7 +60,7 @@ class ValuesTest(unittest.TestCase):
 
   def test_pval_significant(self):
     values = Values([1, 1, 1])
-    self.assertAlmostEqual(0.967, values.pval([10, 10, 10]), places=3)
+    self.assertAlmostEqual(0.900, values.pval([10, 10, 10]), places=3)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**What this PR does and why we need it:**

To fix the failing CI builds on Mac (Fixes https://github.com/bazelbuild/bazel/issues/12076)

Also dropping the `ubuntu1604` environment, as we no longer do benchmarks on it (Fixes #99 )