### PR TITLE
Add log message about individual runs.

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -257,6 +257,13 @@ def _single_run(bazel_bin_path,
   measurements = bazel.command(
       command, args=options + targets, collect_memory=collect_memory)
 
+  logger.log('Results of this run: wall: ' +
+          '%.3fs, cpu %.3fs, system %.3fs, memory %.3fMB' % (
+              measurements['wall'],
+              measurements['cpu'],
+              measurements['system'],
+              measurements['memory']))
+
   # Get back to a clean state.
   bazel.command('clean', ['--color=no'])
   bazel.command('shutdown')

--- a/benchmark.py
+++ b/benchmark.py
@@ -259,11 +259,12 @@ def _single_run(bazel_bin_path,
 
   if measurements != None:
       logger.log('Results of this run: wall: ' +
-              '%.3fs, cpu %.3fs, system %.3fs, memory %.3fMB' % (
+              '%.3fs, cpu %.3fs, system %.3fs, memory %.3fMB, exit_status: %d' % (
                   measurements['wall'],
                   measurements['cpu'],
                   measurements['system'],
-                  measurements['memory']))
+                  measurements['memory'],
+                  measurements['exit_status']))
 
   # Get back to a clean state.
   bazel.command('clean', ['--color=no'])

--- a/benchmark.py
+++ b/benchmark.py
@@ -257,12 +257,13 @@ def _single_run(bazel_bin_path,
   measurements = bazel.command(
       command, args=options + targets, collect_memory=collect_memory)
 
-  logger.log('Results of this run: wall: ' +
-          '%.3fs, cpu %.3fs, system %.3fs, memory %.3fMB' % (
-              measurements['wall'],
-              measurements['cpu'],
-              measurements['system'],
-              measurements['memory']))
+  if measurements != None:
+      logger.log('Results of this run: wall: ' +
+              '%.3fs, cpu %.3fs, system %.3fs, memory %.3fMB' % (
+                  measurements['wall'],
+                  measurements['cpu'],
+                  measurements['system'],
+                  measurements['memory']))
 
   # Get back to a clean state.
   bazel.command('clean', ['--color=no'])


### PR DESCRIPTION
Already exposes some info while the script is still running.

Example:
```
I1126 16:58:52.522313 140285878904640 logger.py:34] Preparing /home/twerth/bazel clone.
I1126 16:58:52.522784 140285878904640 logger.py:34] Path /home/twerth/.bazel-bench/project-clones/d8eb7a85967b22409442664d380222c0 exists. Updating...
I1126 16:58:52.687012 140285878904640 logger.py:34] === BENCHMARKING BAZEL: /usr/bin/bazel-real, PROJECT: 5a91c25ca43547870bcf73cf4b427277c7f62d8d ===
I1126 16:58:52.687237 140285878904640 logger.py:34] Pre-fetching external dependencies...
I1126 16:58:52.687336 140285878904640 logger.py:34] Executing Bazel command: bazel  build --sandbox_tmpfs_path=/tmp --nostamp --noshow_progress --color=no
Starting local Bazel server and connecting to it...
I1126 16:58:55.809604 140285878904640 logger.py:34] Results of this run: wall: 1.557s, cpu 6.930s, system 0.270s, memory 24.000MB
I1126 16:58:55.809954 140285878904640 logger.py:34] Executing Bazel command: bazel  clean --color=no
I1126 16:58:55.890132 140285878904640 logger.py:34] Executing Bazel command: bazel  shutdown 
I1126 16:58:56.319232 140285878904640 logger.py:34] Starting benchmark run 1/1:
I1126 16:58:56.319835 140285878904640 logger.py:34] Executing Bazel command: bazel  build --sandbox_tmpfs_path=/tmp --nostamp --noshow_progress --color=no
Starting local Bazel server and connecting to it...
I1126 16:58:59.419131 140285878904640 logger.py:34] Results of this run: wall: 1.547s, cpu 7.080s, system 0.310s, memory 24.000MB
I1126 16:58:59.419399 140285878904640 logger.py:34] Executing Bazel command: bazel  clean --color=no
I1126 16:58:59.498268 140285878904640 logger.py:34] Executing Bazel command: bazel  shutdown 
```