### PR TITLE
Fix JSON aggregator crashing with benchmark config

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -677,13 +677,15 @@ def main(argv):
     output_handling.export_csv(data_directory, csv_file_name, csv_data)
     output_handling.export_file(data_directory, txt_file_name, summary_text)
 
-    if FLAGS.aggregate_json_profiles:
+    # This is mostly for the nightly benchmark, hence the flags assumptions.
+    if (FLAGS.aggregate_json_profiles and FLAGS.bazel_commits 
+        and FLAGS.project_commits and not FLAGS.benchmark_config):
       aggr_json_profiles_csv_path = (
           '%s/%s' % (FLAGS.data_directory, DEFAULT_AGGR_JSON_PROFILE_FILENAME))
       handle_json_profiles_aggr(
-          bazel_commits,
+          FLAGS.bazel_commits,
           FLAGS.project_source,
-          project_commits,
+          FLAGS.project_commits,
           FLAGS.runs,
           output_prefix=bazel_bench_uid,
           output_path=aggr_json_profiles_csv_path,

--- a/benchmark.py
+++ b/benchmark.py
@@ -549,9 +549,7 @@ def _get_benchmark_config_and_clone_repos(argv):
   """
   if FLAGS.benchmark_config:
     config = BenchmarkConfig.from_file(FLAGS.benchmark_config)
-    # We don't allow multiple project_source for now.
-    first_unit = config.get_units()[0]
-    project_source = first_unit['project_source']
+    project_source = config.get_project_source()
     project_clone_repo = _setup_project_repo(
         PROJECT_CLONE_BASE_PATH + '/' + _get_clone_subdir(project_source),
         project_source)
@@ -677,15 +675,14 @@ def main(argv):
     output_handling.export_csv(data_directory, csv_file_name, csv_data)
     output_handling.export_file(data_directory, txt_file_name, summary_text)
 
-    # This is mostly for the nightly benchmark, hence the flags assumptions.
-    if (FLAGS.aggregate_json_profiles and FLAGS.bazel_commits 
-        and FLAGS.project_commits and not FLAGS.benchmark_config):
+    # This is mostly for the nightly benchmark.
+    if FLAGS.aggregate_json_profiles:
       aggr_json_profiles_csv_path = (
           '%s/%s' % (FLAGS.data_directory, DEFAULT_AGGR_JSON_PROFILE_FILENAME))
       handle_json_profiles_aggr(
-          FLAGS.bazel_commits,
-          FLAGS.project_source,
-          FLAGS.project_commits,
+          config.get_bazel_commits(),
+          config.get_project_source(),
+          config.get_project_commits(),
           FLAGS.runs,
           output_prefix=bazel_bench_uid,
           output_path=aggr_json_profiles_csv_path,

--- a/utils/benchmark_config.py
+++ b/utils/benchmark_config.py
@@ -83,6 +83,25 @@ class BenchmarkConfig(object):
   def get_units(self):
     """Returns a copy of the parsed units."""
     return copy.copy(self._units)
+  
+  def get_bazel_commits(self):	
+    """Returns the list of specified bazel_commits."""	
+    return [	
+        unit['bazel_commit'] for unit in self._units if 'bazel_commit' in unit	
+    ]
+
+  def get_project_commits(self):	
+    """Returns the list of specified project_commits."""	
+    return [	
+        unit['project_commit'] for unit in self._units if 'project_commit' in unit	
+    ]
+
+  def get_project_source(self):
+    """Returns the common project_source across the units.
+    
+    We don't allow multiple project_source for now.
+    """
+    return None if not self._units else self._units[0]['project_source']
 
   def benchmark_project_commits(self):
     """Returns whether we're benchmarking project commits (instead of bazel commits)."""


### PR DESCRIPTION
**What this PR does and why we need it:**

The nightly benchmark crashed here. This PR fixes the crash by providing the json aggregator with info from the benchmark config object.