### PR TITLE
Fix missing project source in summary text.

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -388,7 +388,7 @@ def handle_json_profiles_aggr(bazel_commits, project_source, project_commits,
   logger.log('Finished writing aggregate_json_profiles to %s' % output_path)
 
 
-def create_summary(data):
+def create_summary(data, project_source):
   """Creates the runs summary onto stdout.
 
   Excludes runs with non-zero exit codes from the final summary table.
@@ -404,7 +404,7 @@ def create_summary(data):
   last_collected = None
   for (bazel_commit, project_commit), collected in data.items():
     header = ('Bazel commit: %s, Project commit: %s, Project source: %s' %
-              (bazel_commit, project_commit, FLAGS.project_source))
+              (bazel_commit, project_commit, project_source))
     summary_builder.append(header)
 
     summary_builder.append(
@@ -665,7 +665,7 @@ def main(argv):
         'non_measurables': non_measurables
     }
 
-  summary_text = create_summary(data)
+  summary_text = create_summary(data, config.get_project_source())
   print(summary_text)
 
   if FLAGS.data_directory:


### PR DESCRIPTION
**What this PR does and why we need it:**

project_source was missing in the summary. This PR fixes that.

Before:
```
RESULTS:
Bazel commit: 520c0f912e510f69e4457ea935f18a1b35df3932, Project commit: b1c40e1de81913a3c40e5948f78719c28152486d, Project source: None
  metric          mean                median          stddev      pval   
    wall:    1.115s               1.115s              0.000s             
     cpu:    8.830s               8.830s              0.000s             
  system:    0.700s               0.700s              0.000s             
  memory:   27.000MB             27.000MB             0.000MB            

Bazel commit: 20f62f87c40c5f83eb65b4417cf28f1d800013b0, Project commit: b1c40e1de81913a3c40e5948f78719c28152486d, Project source: None
  metric          mean                median          stddev      pval   
    wall:    1.092s  ( -2.02%)    1.092s  ( -2.02%)   0.000s    -1.00000 
     cpu:    7.940s  (-10.08%)    7.940s  (-10.08%)   0.000s    -1.00000 
  system:    0.830s  (+18.57%)    0.830s  (+18.57%)   0.000s    -1.00000 
  memory:   27.000MB ( +0.00%)   27.000MB ( +0.00%)   0.000MB   -1.00000 
```


After:
```
RESULTS:
Bazel commit: 520c0f912e510f69e4457ea935f18a1b35df3932, Project commit: b1c40e1de81913a3c40e5948f78719c28152486d, Project source: https://github.com/bazelbuild/rules_cc.git
  metric          mean                median          stddev      pval   
    wall:    1.115s               1.115s              0.000s             
     cpu:    8.830s               8.830s              0.000s             
  system:    0.700s               0.700s              0.000s             
  memory:   27.000MB             27.000MB             0.000MB            

Bazel commit: 20f62f87c40c5f83eb65b4417cf28f1d800013b0, Project commit: b1c40e1de81913a3c40e5948f78719c28152486d, Project source: https://github.com/bazelbuild/rules_cc.git
  metric          mean                median          stddev      pval   
    wall:    1.092s  ( -2.02%)    1.092s  ( -2.02%)   0.000s    -1.00000 
     cpu:    7.940s  (-10.08%)    7.940s  (-10.08%)   0.000s    -1.00000 
  system:    0.830s  (+18.57%)    0.830s  (+18.57%)   0.000s    -1.00000 
  memory:   27.000MB ( +0.00%)   27.000MB ( +0.00%)   0.000MB   -1.00000
```