### PR TITLE
Make memory collection the default and only behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,6 @@ config-file interface. The example config file would look like this:
 global_options:
   project_commit: 595a730
   runs: 3
-  collect_memory: true
   collect_profile: false
   project_source: /path/to/project/repo
 units:
@@ -148,10 +147,8 @@ Some useful flags are:
   --bazel_source: Either a path to the local Bazel repo or a https url to a GitHub repository.
     (default: 'https://github.com/bazelbuild/bazel.git')
   --bazelrc: The path to a .bazelrc file.
-  --[no]collect_memory: Whether to collect used heap sizes.
-    (default: 'false')
   --csv_file_name: The name of the output csv, without the .csv extension
-  --data_directory: The directory in which the csv files should be stored. Turns on memory collection.
+  --data_directory: The directory in which the csv files should be stored.
   --[no]prefetch_ext_deps: Whether to do an initial run to pre-fetch external dependencies.
     (default: 'true')
   --project_commits: The commits from the git project to be benchmarked.

--- a/benchmark.py
+++ b/benchmark.py
@@ -223,8 +223,7 @@ def _single_run(bazel_bin_path,
                 command,
                 options,
                 targets,
-                startup_options,
-                collect_memory=False):
+                startup_options):
   """Runs the benchmarking for a combination of (bazel version, project version).
 
   Args:
@@ -233,7 +232,6 @@ def _single_run(bazel_bin_path,
     options: the list of options.
     targets: the list of targets.
     startup_options: the list of target options.
-    collect_memory: whether the benchmarking should collect memory info.
 
   Returns:
     A result object:
@@ -254,8 +252,7 @@ def _single_run(bazel_bin_path,
   # The order in which the options appear matters.
   if command == 'build':
     options = options + ['--nostamp', '--noshow_progress', '--color=no']
-  measurements = bazel.command(
-      command, args=options + targets, collect_memory=collect_memory)
+  measurements = bazel.command(command, args=options + targets)
 
   if measurements != None:
       logger.log('Results of this run: wall: ' +
@@ -275,7 +272,6 @@ def _single_run(bazel_bin_path,
 def _run_benchmark(bazel_bin_path,
                    project_path,
                    runs,
-                   collect_memory,
                    command,
                    options,
                    targets,
@@ -293,7 +289,6 @@ def _run_benchmark(bazel_bin_path,
     bazel_bin_path: the path to the bazel binary to be run.
     project_path: the path to the project clone to be built.
     runs: the number of runs.
-    collect_memory: whether the benchmarking should collect memory info.
     bazel_args: the unparsed list of arguments to be passed to Bazel binary.
     prefetch_ext_deps: whether to do a first non-benchmarked run to fetch the
       external dependencies.
@@ -319,8 +314,7 @@ def _run_benchmark(bazel_bin_path,
   # Runs the command once to make sure external dependencies are fetched.
   if prefetch_ext_deps:
     logger.log('Pre-fetching external dependencies...')
-    _single_run(bazel_bin_path, command, options, targets, startup_options,
-                collect_memory)
+    _single_run(bazel_bin_path, command, options, targets, startup_options)
 
   if collect_json_profile:
     if not os.path.exists(data_directory):
@@ -341,7 +335,7 @@ def _run_benchmark(bazel_bin_path,
                                 project_commit, i, runs))
     collected.append(
         _single_run(bazel_bin_path, command, maybe_include_json_profile_flags,
-                    targets, startup_options, collect_memory))
+                    targets, startup_options))
 
   return collected, (command, targets, options)
 
@@ -498,8 +492,6 @@ flags.DEFINE_string('platform', None,
 # Miscellaneous flags.
 flags.DEFINE_boolean('verbose', False,
                      'Whether to include git/Bazel stdout logs.')
-flags.DEFINE_boolean('collect_memory', False,
-                     'Whether to collect used heap sizes.')
 flags.DEFINE_boolean('prefetch_ext_deps', True,
                      'Whether to do an initial run to pre-fetch external ' \
                      'dependencies.')
@@ -586,7 +578,6 @@ def _get_benchmark_config_and_clone_repos(argv):
   config = BenchmarkConfig.from_flags(bazel_commits, bazel_binaries,
                                       project_commits, bazel_source,
                                       FLAGS.project_source, FLAGS.runs,
-                                      FLAGS.collect_memory,
                                       FLAGS.collect_json_profile,
                                       ' '.join(bazel_args))
 
@@ -635,7 +626,6 @@ def main(argv):
         bazel_bin_path=unit['bazel_bin_path'],
         project_path=project_clone_repo.working_dir,
         runs=unit['runs'],
-        collect_memory=unit['collect_memory'] or FLAGS.data_directory,
         command=unit['command'],
         options=unit['options'],
         targets=unit['targets'],

--- a/benchmark.py
+++ b/benchmark.py
@@ -507,8 +507,7 @@ flags.DEFINE_string(
 
 # Output storage flags.
 flags.DEFINE_string('data_directory', None,
-                    'The directory in which the csv files should be stored. ' \
-                    'Turns on memory collection.')
+                    'The directory in which the csv files should be stored.')
 # The daily report generation process on BazelCI requires the csv file name to
 # be determined before bazel-bench is launched, so that METADATA files are
 # properly filled.

--- a/benchmark_test.py
+++ b/benchmark_test.py
@@ -125,8 +125,7 @@ class BenchmarkFunctionTests(absltest.TestCase):
           'build',
           options=[],
           targets=['//:all'],
-          startup_options=[],
-          collect_memory=False)
+          startup_options=[])
 
     self.assertEqual(
         ''.join([
@@ -143,7 +142,6 @@ class BenchmarkFunctionTests(absltest.TestCase):
           'project_path',
           runs=2,
           bazel_bench_uid='fake_uid',
-          collect_memory=False,
           command='build',
           options=[],
           targets=['//:all'],
@@ -172,7 +170,6 @@ class BenchmarkFunctionTests(absltest.TestCase):
           'project_path',
           runs=2,
           bazel_bench_uid='fake_uid',
-          collect_memory=False,
           command='build',
           options=[],
           targets=['//:all'],
@@ -205,7 +202,6 @@ class BenchmarkFunctionTests(absltest.TestCase):
           'project_path',
           runs=2,
           bazel_bench_uid='fake_uid',
-          collect_memory=False,
           command='build',
           options=[],
           targets=['//:all'],

--- a/utils/bazel.py
+++ b/utils/bazel.py
@@ -37,16 +37,13 @@ class Bazel(object):
     self._startup_options = startup_options
     self._pid = None
 
-  def command(self, command, args=None, collect_memory=False):
+  def command(self, command, args=None):
     """Invokes a command with a bazel binary.
 
     Args:
       command: A string specifying the bazel command to invoke.
       args: An optional list of strings representing additional arguments to the
         bazel command.
-      collect_memory: A boolean specifying whether to collect memory information
-        for this command. Note that this retrieves the heap size from bazel a
-        number of times to get stable data.
 
     Returns:
       A dict containing collected metrics (wall, cpu, system times and
@@ -82,9 +79,8 @@ class Bazel(object):
       result[kind] = after_times[kind] - before_times[kind]
     result['exit_status'] = exit_status
 
-    if collect_memory:
-      # We do a number of runs here to reduce the noise in the data.
-      result['memory'] = min([self._get_heap_size() for _ in range(5)])
+    # We do a number of runs here to reduce the noise in the data.
+    result['memory'] = min([self._get_heap_size() for _ in range(5)])
 
     return result
 

--- a/utils/bazel_test.py
+++ b/utils/bazel_test.py
@@ -82,7 +82,7 @@ class BazelTest(unittest.TestCase):
             'started_at': 'fake_date'
         },
         b.command(
-            command='build', args=['bar', 'zoo'], collect_memory=True))
+            command='build', args=['bar', 'zoo']))
     subprocess_mock.assert_called_with(
         ['foo', 'build', 'bar', 'zoo'], stdout=mock.ANY, stderr=mock.ANY)
 

--- a/utils/benchmark_config.py
+++ b/utils/benchmark_config.py
@@ -63,7 +63,6 @@ class BenchmarkConfig(object):
   # TODO(leba): Consider replacing dict with collections.namedtuple.
   _DEFAULT_VALS = {
       'runs': 3,
-      'collect_memory': False,
       'collect_profile': False,
       'bazel_source': 'https://github.com/bazelbuild/bazel.git'
   }
@@ -158,8 +157,7 @@ class BenchmarkConfig(object):
 
   @classmethod
   def from_flags(cls, bazel_commits, bazel_binaries, project_commits,
-                 bazel_source, project_source, runs, collect_memory,
-                 collect_profile, command):
+                 bazel_source, project_source, runs, collect_profile, command):
     """Creates the BenchmarkConfig based on specified flags.
 
     Args:
@@ -171,7 +169,6 @@ class BenchmarkConfig(object):
       project_source: Either a path to the local git project to be built or a
         https url to a GitHub repository
       runs: The number of benchmark runs to perform for each combination.
-      collect_memory: Whether to collect Blaze memory consumption.
       collect_profile: Whether to collect a JSON profile.
       command: the full command to benchmark, optionally with startup options
         prepended, e.g. "--noexobazel build --nobuild ...".
@@ -189,7 +186,6 @@ class BenchmarkConfig(object):
                 'bazel_source': bazel_source,
                 'project_source': project_source,
                 'runs': runs,
-                'collect_memory': collect_memory,
                 'collect_profile': collect_profile,
                 'command': command,
             }))
@@ -202,7 +198,6 @@ class BenchmarkConfig(object):
                 'bazel_source': bazel_source,
                 'project_source': project_source,
                 'runs': runs,
-                'collect_memory': collect_memory,
                 'collect_profile': collect_profile,
                 'command': command,
             }))

--- a/utils/benchmark_config.py
+++ b/utils/benchmark_config.py
@@ -19,7 +19,6 @@ Currently supported flags/attributes:
 - bazel_commit
 - bazel_binary
 - runs
-- collect_memory
 - collect_profile
 - the command (which includes startup options, command, targets, command
 options)
@@ -32,7 +31,6 @@ benchmark_project_commits: False
 global_options:
   project_commit: 595a730
   runs: 3
-  collect_memory: true
   collect_profile: false
   project_source: /path/to/project/repo
 units:

--- a/utils/benchmark_config_test.py
+++ b/utils/benchmark_config_test.py
@@ -46,7 +46,6 @@ units:
         'project_commit': 'hash1',
         'bazel_source': 'https://github.com/bazelbuild/bazel.git',
         'runs': 3,
-        'collect_memory': False,
         'collect_profile': False,
         'command': 'info',
         'startup_options': [],
@@ -63,7 +62,6 @@ benchmark_project_commits: False
 global_options:
   project_commit: 'hash3'
   runs: 3
-  collect_memory: true
 units:
  - bazel_commit: hash1
    command: info
@@ -78,7 +76,6 @@ units:
         'project_commit': 'hash3',
         'bazel_source': 'https://github.com/bazelbuild/bazel.git',
         'runs': 3,
-        'collect_memory': True,
         'collect_profile': False,
         'command': 'info',
         'startup_options': [],
@@ -89,7 +86,6 @@ units:
         'project_commit': 'hash2',
         'bazel_source': 'https://github.com/bazelbuild/bazel.git',
         'runs': 3,
-        'collect_memory': True,
         'collect_profile': False,
         'command': 'build',
         'startup_options': [],
@@ -107,7 +103,6 @@ units:
         bazel_source='foo',
         project_source='foo',
         runs=3,
-        collect_memory=True,
         collect_profile=False,
         command='build --nobuild //abc')
     self.assertEqual(result._units, [{
@@ -116,7 +111,6 @@ units:
         'bazel_source': 'foo',
         'project_source': 'foo',
         'runs': 3,
-        'collect_memory': True,
         'collect_profile': False,
         'command': 'build',
         'startup_options': [],
@@ -128,7 +122,6 @@ units:
         'bazel_source': 'foo',
         'project_source': 'foo',
         'runs': 3,
-        'collect_memory': True,
         'collect_profile': False,
         'command': 'build',
         'startup_options': [],
@@ -144,7 +137,6 @@ units:
         'project_commit': 'hash2',
         'runs': 3,
         'bazelrc': None,
-        'collect_memory': True,
         'collect_profile': False,
         'warmup_runs': 1,
         'shutdown': True,
@@ -157,7 +149,6 @@ units:
         'project_commit': 'hash2',
         'runs': 3,
         'bazelrc': None,
-        'collect_memory': True,
         'collect_profile': False,
         'warmup_runs': 1,
         'shutdown': True,


### PR DESCRIPTION
**What this PR does and why we need it:**

This makes the script interface a bit simpler (1 fewer flag), and reduces the risk of users forgetting to turn on this flag. The memory collection is done _after_ each build so it doesn't affect the other numbers.

TODO:
- [ ] Update the bazel-bench-nightly pipeline to remove `--collect_memory=True`.