### PR TITLE
Bump default number of runs from 3 to 5.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ config-file interface. The example config file would look like this:
 # config.yaml
 global_options:
   project_commit: 595a730
-  runs: 3
+  runs: 5
   collect_profile: false
   project_source: /path/to/project/repo
 units:
@@ -156,7 +156,7 @@ Some useful flags are:
     (a comma separated list)
   --project_source: Either a path to the local git project to be built or a https url to a GitHub repository.
   --runs: The number of benchmark runs.
-    (default: '3')
+    (default: '5')
     (an integer)
   --[no]verbose: Whether to include git/Bazel stdout logs.
     (default: 'false')

--- a/benchmark.py
+++ b/benchmark.py
@@ -482,7 +482,7 @@ flags.DEFINE_string(
     "The shell commands to configure the project's environment .")
 
 # Execution options.
-flags.DEFINE_integer('runs', 3, 'The number of benchmark runs.')
+flags.DEFINE_integer('runs', 5, 'The number of benchmark runs.')
 flags.DEFINE_string('bazelrc', None, 'The path to a .bazelrc file.')
 flags.DEFINE_string('platform', None,
                     ('The platform on which bazel-bench is run. This is just '

--- a/utils/benchmark_config.py
+++ b/utils/benchmark_config.py
@@ -30,7 +30,7 @@ Example of a config file:
 benchmark_project_commits: False
 global_options:
   project_commit: 595a730
-  runs: 3
+  runs: 5
   collect_profile: false
   project_source: /path/to/project/repo
 units:
@@ -60,7 +60,7 @@ class BenchmarkConfig(object):
   # TODO(leba): have a single source of truth for this.
   # TODO(leba): Consider replacing dict with collections.namedtuple.
   _DEFAULT_VALS = {
-      'runs': 3,
+      'runs': 5,
       'collect_profile': False,
       'bazel_source': 'https://github.com/bazelbuild/bazel.git'
   }

--- a/utils/benchmark_config_test.py
+++ b/utils/benchmark_config_test.py
@@ -45,7 +45,7 @@ units:
         'bazel_commit': 'hash1',
         'project_commit': 'hash1',
         'bazel_source': 'https://github.com/bazelbuild/bazel.git',
-        'runs': 3,
+        'runs': 5,
         'collect_profile': False,
         'command': 'info',
         'startup_options': [],
@@ -61,7 +61,7 @@ units:
 benchmark_project_commits: False
 global_options:
   project_commit: 'hash3'
-  runs: 3
+  runs: 5
 units:
  - bazel_commit: hash1
    command: info
@@ -75,7 +75,7 @@ units:
         'bazel_commit': 'hash1',
         'project_commit': 'hash3',
         'bazel_source': 'https://github.com/bazelbuild/bazel.git',
-        'runs': 3,
+        'runs': 5,
         'collect_profile': False,
         'command': 'info',
         'startup_options': [],
@@ -85,7 +85,7 @@ units:
         'bazel_path': '/tmp/bazel',
         'project_commit': 'hash2',
         'bazel_source': 'https://github.com/bazelbuild/bazel.git',
-        'runs': 3,
+        'runs': 5,
         'collect_profile': False,
         'command': 'build',
         'startup_options': [],
@@ -102,7 +102,7 @@ units:
         project_commits=['hash3'],
         bazel_source='foo',
         project_source='foo',
-        runs=3,
+        runs=5,
         collect_profile=False,
         command='build --nobuild //abc')
     self.assertEqual(result._units, [{
@@ -110,7 +110,7 @@ units:
         'project_commit': 'hash3',
         'bazel_source': 'foo',
         'project_source': 'foo',
-        'runs': 3,
+        'runs': 5,
         'collect_profile': False,
         'command': 'build',
         'startup_options': [],
@@ -121,7 +121,7 @@ units:
         'project_commit': 'hash3',
         'bazel_source': 'foo',
         'project_source': 'foo',
-        'runs': 3,
+        'runs': 5,
         'collect_profile': False,
         'command': 'build',
         'startup_options': [],
@@ -135,7 +135,7 @@ units:
     config = benchmark_config.BenchmarkConfig([{
         'bazel_commit': 'hash1',
         'project_commit': 'hash2',
-        'runs': 3,
+        'runs': 5,
         'bazelrc': None,
         'collect_profile': False,
         'warmup_runs': 1,
@@ -147,7 +147,7 @@ units:
     }, {
         'bazel_commit': '/tmp/bazel',
         'project_commit': 'hash2',
-        'runs': 3,
+        'runs': 5,
         'bazelrc': None,
         'collect_profile': False,
         'warmup_runs': 1,


### PR DESCRIPTION
Less than 5 runs rarely show meaningful results.
