### PR TITLE
Bump google-resumable-media.

### DIFF
--- a/third_party/requirements.txt
+++ b/third_party/requirements.txt
@@ -11,7 +11,7 @@ google-auth==1.6.3
 google-cloud-bigquery==1.9.0
 google-cloud-storage==1.13.2
 google-cloud-core==0.29.1
-google-resumable-media==0.3.2
+google-resumable-media==1.3.1
 googleapis-common-protos==1.6.0
 idna==2.8
 mock==2.0.0


### PR DESCRIPTION
https://github.com/bazelbuild/bazel-bench/commit/0ad9b557594716517672e5b51c03bf8928ab2829 broke our nightly benchmarks. This commit attempts to fix it.

**What this PR does and why we need it:**

> Replace this line with your answer.

**New changes / Issues that this PR fixes:**

> Replace this line with your answer.

**Special notes for reviewer:**

> Replace this line with your answer.

**Does this require a change in the script's interface or the BigQuery's table structure?**

> Replace this line with your answer.
