### PR TITLE
Make dependency on cython explicit.

### DIFF
--- a/third_party/requirements.txt
+++ b/third_party/requirements.txt
@@ -28,3 +28,4 @@ scipy==1.5.0
 six==1.12.0
 urllib3==1.26.5
 PyYAML==3.13
+cython==0.29.24


### PR DESCRIPTION
Add a explicit dependency on cpython to make it work on glinux machines.