### PR TITLE
Support benchmark units with the same bazel_commit/bazel_binary

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -213,10 +213,11 @@ def _construct_json_profile_flags(out_file_path):
 
 
 def json_profile_filename(data_directory, bazel_bench_uid, bazel_commit,
-                          project_commit, run_number, total_runs):
-  return '%s/%s_%s_%s_%s_of_%s.profile.gz' % (data_directory, bazel_bench_uid,
-                                              bazel_commit, project_commit,
-                                              run_number, total_runs)
+                          unit_num, project_commit, run_number, total_runs):
+  return '%s/%s_%s_%d_%s_%s_of_%s.profile.gz' % (data_directory, bazel_bench_uid,
+                                                bazel_commit, unit_num,
+                                                project_commit, run_number,
+                                                total_runs)
 
 
 def _single_run(bazel_bin_path,
@@ -278,7 +279,7 @@ def _run_benchmark(bazel_bin_path,
                    startup_options,
                    prefetch_ext_deps,
                    bazel_bench_uid,
-                   bep_json_dir=None,
+                   unit_num,
                    data_directory=None,
                    collect_json_profile=False,
                    bazel_identifier=None,
@@ -293,8 +294,7 @@ def _run_benchmark(bazel_bin_path,
     prefetch_ext_deps: whether to do a first non-benchmarked run to fetch the
       external dependencies.
     bazel_bench_uid: a unique string identifier of this entire bazel-bench run.
-    bep_json_dir: absolute path to the directory to write the build event json
-      file to.
+    unit_num: the numerical order of the current unit being benchmarked.
     collect_json_profile: whether to collect JSON profile for each run.
     data_directory: the path to the directory to store run data. Required if
       collect_json_profile.
@@ -309,8 +309,8 @@ def _run_benchmark(bazel_bin_path,
   collected = []
   os.chdir(project_path)
 
-  logger.log('=== BENCHMARKING BAZEL: %s, PROJECT: %s ===' %
-             (bazel_identifier, project_commit))
+  logger.log('=== BENCHMARKING BAZEL [Unit #%d]: %s, PROJECT: %s ===' %
+             (unit_num, bazel_identifier, project_commit))
   # Runs the command once to make sure external dependencies are fetched.
   if prefetch_ext_deps:
     logger.log('Pre-fetching external dependencies...')
@@ -331,7 +331,7 @@ def _run_benchmark(bazel_bin_path,
                               'collect_json_profile')
       maybe_include_json_profile_flags += _construct_json_profile_flags(
           json_profile_filename(data_directory, bazel_bench_uid,
-                                bazel_identifier.replace('/', '_'),
+                                bazel_identifier.replace('/', '_'), unit_num,
                                 project_commit, i, runs))
     collected.append(
         _single_run(bazel_bin_path, command, maybe_include_json_profile_flags,
@@ -396,9 +396,9 @@ def create_summary(data, project_source):
   summary_builder = []
   summary_builder.append('\nRESULTS:')
   last_collected = None
-  for (bazel_commit, project_commit), collected in data.items():
-    header = ('Bazel version: %s, Project commit: %s, Project source: %s' %
-              (bazel_commit, project_commit, project_source))
+  for (i, bazel_commit, project_commit), collected in data.items():
+    header = ('[Unit #%d] Bazel version: %s, Project commit: %s, Project source: %s' %
+              (i, bazel_commit, project_commit, project_source))
     summary_builder.append(header)
 
     summary_builder.append(
@@ -612,8 +612,7 @@ def main(argv):
       unit['bazel_bin_path'] = bazel_bin_path
 
   for i, unit in enumerate(config.get_units()):
-    bazel_identifier = '{}_unit_{}'.format(
-        unit['bazel_commit'] if 'bazel_commit' in unit else unit['bazel_binary'], i)
+    bazel_identifier = unit['bazel_commit'] if 'bazel_commit' in unit else unit['bazel_binary']
     project_commit = unit['project_commit']
 
     project_clone_repo.git.checkout('-f', project_commit)
@@ -631,6 +630,7 @@ def main(argv):
         startup_options=unit['startup_options'],
         prefetch_ext_deps=FLAGS.prefetch_ext_deps,
         bazel_bench_uid=bazel_bench_uid,
+        unit_num=i,
         collect_json_profile=unit['collect_profile'],
         data_directory=data_directory,
         bazel_identifier=bazel_identifier,
@@ -642,7 +642,7 @@ def main(argv):
           collected[metric] = Values()
         collected[metric].add(value)
 
-    data[(bazel_identifier, project_commit)] = collected
+    data[(i, bazel_identifier, project_commit)] = collected
     non_measurables = {
       'project_source': unit['project_source'],
       'platform': FLAGS.platform,

--- a/benchmark.py
+++ b/benchmark.py
@@ -397,7 +397,7 @@ def create_summary(data, project_source):
   summary_builder.append('\nRESULTS:')
   last_collected = None
   for (bazel_commit, project_commit), collected in data.items():
-    header = ('Bazel commit: %s, Project commit: %s, Project source: %s' %
+    header = ('Bazel version: %s, Project commit: %s, Project source: %s' %
               (bazel_commit, project_commit, project_source))
     summary_builder.append(header)
 
@@ -611,9 +611,9 @@ def main(argv):
                                            bazel_bin_base_path, FLAGS.platform)
       unit['bazel_bin_path'] = bazel_bin_path
 
-  for unit in config.get_units():
-    bazel_identifier = unit['bazel_commit'] if 'bazel_commit' in unit else unit[
-        'bazel_binary']
+  for i, unit in enumerate(config.get_units()):
+    bazel_identifier = '{}_unit_{}'.format(
+        unit['bazel_commit'] if 'bazel_commit' in unit else unit['bazel_binary'], i)
     project_commit = unit['project_commit']
 
     project_clone_repo.git.checkout('-f', project_commit)

--- a/benchmark_test.py
+++ b/benchmark_test.py
@@ -146,11 +146,12 @@ class BenchmarkFunctionTests(absltest.TestCase):
           options=[],
           targets=['//:all'],
           startup_options=[],
-          prefetch_ext_deps=False)
+          prefetch_ext_deps=False,
+          unit_num=0)
 
     self.assertEqual(
         ''.join([
-            '=== BENCHMARKING BAZEL: None, PROJECT: None ===',
+            '=== BENCHMARKING BAZEL [Unit #0]: None, PROJECT: None ===',
             'Starting benchmark run 1/2:',
             'Executing Bazel command: bazel build --nostamp --noshow_progress --color=no //:all',
             'Executing Bazel command: bazel clean --color=no',
@@ -174,11 +175,12 @@ class BenchmarkFunctionTests(absltest.TestCase):
           options=[],
           targets=['//:all'],
           startup_options=[],
-          prefetch_ext_deps=True)
+          prefetch_ext_deps=True,
+          unit_num=0)
 
     self.assertEqual(
         ''.join([
-            '=== BENCHMARKING BAZEL: None, PROJECT: None ===',
+            '=== BENCHMARKING BAZEL [Unit #0]: None, PROJECT: None ===',
             'Pre-fetching external dependencies...',
             'Executing Bazel command: bazel build --nostamp --noshow_progress --color=no //:all',
             'Executing Bazel command: bazel clean --color=no',
@@ -210,21 +212,22 @@ class BenchmarkFunctionTests(absltest.TestCase):
           collect_json_profile=True,
           data_directory='fake_dir',
           bazel_identifier='fake_bazel_commit',
-          project_commit='fake_project_commit')
+          project_commit='fake_project_commit',
+          unit_num=0)
 
     self.assertEqual(
         ''.join([
-            '=== BENCHMARKING BAZEL: fake_bazel_commit, PROJECT: fake_project_commit ===',
+            '=== BENCHMARKING BAZEL [Unit #0]: fake_bazel_commit, PROJECT: fake_project_commit ===',
             'Pre-fetching external dependencies...',
             'Executing Bazel command: bazel build --nostamp --noshow_progress --color=no //:all',
             'Executing Bazel command: bazel clean --color=no',
             'Executing Bazel command: bazel shutdown ',
             'Starting benchmark run 1/2:',
-            'Executing Bazel command: bazel build --experimental_generate_json_trace_profile --experimental_profile_cpu_usage --experimental_json_trace_compression --profile=fake_dir/fake_uid_fake_bazel_commit_fake_project_commit_1_of_2.profile.gz --nostamp --noshow_progress --color=no //:all',
+            'Executing Bazel command: bazel build --experimental_generate_json_trace_profile --experimental_profile_cpu_usage --experimental_json_trace_compression --profile=fake_dir/fake_uid_fake_bazel_commit_0_fake_project_commit_1_of_2.profile.gz --nostamp --noshow_progress --color=no //:all',
             'Executing Bazel command: bazel clean --color=no',
             'Executing Bazel command: bazel shutdown ',
             'Starting benchmark run 2/2:',
-            'Executing Bazel command: bazel build --experimental_generate_json_trace_profile --experimental_profile_cpu_usage --experimental_json_trace_compression --profile=fake_dir/fake_uid_fake_bazel_commit_fake_project_commit_2_of_2.profile.gz --nostamp --noshow_progress --color=no //:all',
+            'Executing Bazel command: bazel build --experimental_generate_json_trace_profile --experimental_profile_cpu_usage --experimental_json_trace_compression --profile=fake_dir/fake_uid_fake_bazel_commit_0_fake_project_commit_2_of_2.profile.gz --nostamp --noshow_progress --color=no //:all',
             'Executing Bazel command: bazel clean --color=no',
             'Executing Bazel command: bazel shutdown '
         ]), mock_stderr.getvalue())


### PR DESCRIPTION
**What this PR does and why we need it:**

The script previously used the tuple `(bazel_identifier, project_commit)` to identify a data point. This is not enough to differentiate benchmark units, in case we want to benchmark the same bazel commit/binary but with different command lines. This PR fixes that by adding the unit number to this identifying tuple.

Also removed obsolete param `bep_json_dir` in `_run_benchmark`.

Test run:
![Screenshot 2021-08-16 at 17 31 47](https://user-images.githubusercontent.com/10117525/129589431-8d7b446c-a146-40d4-b35f-3a0f5fbf976b.png)

**New changes / Issues that this PR fixes:**

Fixes #113.


