### PR TITLE
Upgrade absl-py version.

### DIFF
--- a/third_party/requirements.txt
+++ b/third_party/requirements.txt
@@ -1,4 +1,4 @@
-absl-py==0.9.0
+absl-py==1.2.0
 cachetools==3.1.0
 certifi==2018.11.29
 chardet==3.0.4


### PR DESCRIPTION
The 0.9.0 version released to PyPI has buggy Python version detection:
https://github.com/abseil/abseil-py/blob/pypi-v0.9.0/setup.py#L33

The check fails on Python 3.10 since ('3', '10') < ('3', '4').