### PR TITLE
Use hermetic Python.

### DIFF
--- a/.bazelci/postsubmit.yml
+++ b/.bazelci/postsubmit.yml
@@ -4,8 +4,6 @@ tasks:
     include_json_profile:
       - build
       - test
-    shell_commands:
-      - pip3 install --user -r third_party/requirements.txt
     build_targets:
       - "//..."
     test_targets:
@@ -14,8 +12,6 @@ tasks:
     include_json_profile:
       - build
       - test
-    shell_commands:
-      - pip3 install --user -r third_party/requirements.txt
     build_targets:
       - "//..."
     test_targets:

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,15 +1,11 @@
 ---
 tasks:
   ubuntu1804:
-    shell_commands:
-      - pip3 install --user -r third_party/requirements.txt
     build_targets:
       - "//..."
     test_targets:
       - "//..."
   macos:
-    shell_commands:
-      - pip3 install --user -r third_party/requirements.txt
     build_targets:
       - "//..."
     test_targets:

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,15 +2,26 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "rules_python",
-    sha256 = "15f84594af9da06750ceb878abbf129241421e3abbd6e36893041188db67f2fb",
-    strip_prefix = "rules_python-0.7.0",
-    url = "https://github.com/bazelbuild/rules_python/archive/refs/tags/0.7.0.tar.gz",
+    sha256 = "a3a6e99f497be089f81ec082882e40246bfd435f52f4e82f37e89449b04573f6",
+    strip_prefix = "rules_python-0.10.2",
+    url = "https://github.com/bazelbuild/rules_python/archive/refs/tags/0.10.2.tar.gz",
 )
 
 load("@rules_python//python:pip.bzl", "pip_install")
+load("@rules_python//python:repositories.bzl", "python_register_toolchains")
+
+# Use a hermetic Python interpreter so that builds are reproducible
+# irrespective of the Python version available on the host machine.
+python_register_toolchains(
+    name = "python3_10",
+    python_version = "3.10",
+)
+
+load("@python3_10//:defs.bzl", "interpreter")
 
 # Translate requirements.txt into a @third_party external repository.
 pip_install(
    name = "third_party",
+   python_interpreter_target = interpreter,
    requirements = "//third_party:requirements.txt",
 )

--- a/third_party/requirements.txt
+++ b/third_party/requirements.txt
@@ -15,7 +15,7 @@ google-resumable-media==1.3.1
 googleapis-common-protos==1.6.0
 idna==2.8
 mock==2.0.0
-numpy==1.18.5
+numpy==1.23.1
 pbr==5.1.3
 protobuf==3.15.0
 psutil==5.8.0
@@ -24,8 +24,8 @@ pyasn1-modules==0.2.4
 pytz==2018.9
 requests==2.25.1
 rsa==4.7
-scipy==1.5.4
+scipy==1.9.0
 six==1.12.0
 urllib3==1.26.5
-PyYAML==3.13
+PyYAML==6.0
 cython==0.29.24


### PR DESCRIPTION
The currently specified versions of scipy and numpy no longer work with
Python 3.10, but their latest versions are not available for Python 3.6,
which is the version available on the Ubuntu 18.04 CI machines.

Using a hermetic interpreter ensures builds are reproducible irrespective
of the interpreter version available on the host machine.

Also note that it's not necessary to run pip on the CI machines. The
Python rules are already able to fetch the dependencies.