### PR TITLE
Fail the script if an external command returns a nonzero exit status.

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -55,22 +55,16 @@ def _get_clone_subdir(project_source):
   return hashlib.md5(project_source.encode('utf-8')).hexdigest()
 
 
-def _exec_command(args, shell=False, fail_if_nonzero=True, cwd=None):
+def _exec_command(args, shell=False, cwd=None):
   logger.log('Executing: %s' % (args if shell else ' '.join(args)))
-  devnull_r = open(os.devnull, 'r')
 
-  if FLAGS.verbose:
-    return subprocess.call(args, shell=shell, cwd=cwd, stdin=devnull_r)
-
-  devnull_w = open(os.devnull, 'w')
-  proc = subprocess.Popen(
+  return subprocess.run(
       args,
       shell=shell,
-      stdin=devnull_r,
-      stdout=devnull_w,
-      stderr=devnull_w,
-      cwd=cwd)
-  return proc.communicate()
+      cwd=cwd,
+      check=True,
+      stdout=sys.stdout if FLAGS.verbose else subprocess.DEVNULL,
+      stderr=sys.stderr if FLAGS.verbose else subprocess.DEVNULL)
 
 
 def _get_commits_topological(commits_sha_list,


### PR DESCRIPTION
Also use subprocess.run() which has a simpler interface than Popen().