### PR TITLE
Fix crash when env_configure is not explicitly given in the command line.

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -628,7 +628,7 @@ def main(argv):
     project_commit = unit['project_commit']
 
     project_clone_repo.git.checkout('-f', project_commit)
-    if 'env_configure' in unit:
+    if unit['env_configure'] is not None:
       _exec_command(
           unit['env_configure'], shell=True, cwd=project_clone_repo.working_dir)
 

--- a/utils/benchmark_config.py
+++ b/utils/benchmark_config.py
@@ -62,7 +62,8 @@ class BenchmarkConfig(object):
   _DEFAULT_VALS = {
       'runs': 5,
       'collect_profile': False,
-      'bazel_source': 'https://github.com/bazelbuild/bazel.git'
+      'bazel_source': 'https://github.com/bazelbuild/bazel.git',
+      'env_configure': None,
   }
 
   def __init__(self, units, benchmark_project_commits=False):

--- a/utils/benchmark_config_test.py
+++ b/utils/benchmark_config_test.py
@@ -50,7 +50,8 @@ units:
         'command': 'info',
         'startup_options': [],
         'options': _pad_test_command_options([]),
-        'targets': []
+        'targets': [],
+        'env_configure': None,
     }])
     self.assertEqual(result._benchmark_project_commits, False)
     os.remove(config_file_path)
@@ -76,6 +77,7 @@ units:
         'bazel_commit': 'hash1',
         'project_commit': 'hash3',
         'bazel_source': 'https://github.com/bazelbuild/bazel.git',
+        'env_configure': None,
         'runs': 5,
         'collect_profile': False,
         'command': 'info',


### PR DESCRIPTION
The `'env_configure' in unit` presence check introduced in 5ce2dea doesn't work, as the command line flag defaults to None but the field might be missing entirely from the configuration file. Instead, normalize its presence and check against None. This mirrors how we handle other configuration fields.