### PR TITLE
Bump rules_python to 0.11.0

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,9 +2,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "rules_python",
-    sha256 = "a3a6e99f497be089f81ec082882e40246bfd435f52f4e82f37e89449b04573f6",
-    strip_prefix = "rules_python-0.10.2",
-    url = "https://github.com/bazelbuild/rules_python/archive/refs/tags/0.10.2.tar.gz",
+    sha256 = "c03246c11efd49266e8e41e12931090b613e12a59e6f55ba2efd29a7cb8b4258",
+    strip_prefix = "rules_python-0.11.0",
+    url = "https://github.com/bazelbuild/rules_python/archive/refs/tags/0.11.0.tar.gz",
 )
 
 load("@rules_python//python:pip.bzl", "pip_install")


### PR DESCRIPTION
**What this PR does and why we need it:**

This is needed in order to flip the disallow empty globs flag.
Version 0.11.0 makes it possible.
0.13.0 is the latest available at the time of this bump.

**New changes / Issues that this PR fixes:**

The idea is to fix the issues of Bazel Bench tests when being run with incompatible_disallow_empty_glob
https://buildkite.com/bazel/bazelisk-plus-incompatible-flags/builds/1301#0183e377-9bfb-43fe-b329-fd314fb22b06

**Special notes for reviewer:**

None

**Does this require a change in the script's interface or the BigQuery's table structure?**

I don't think so but I don't know
