### PR TITLE
Support -- syntax

### DIFF
--- a/utils/benchmark_config.py
+++ b/utils/benchmark_config.py
@@ -234,6 +234,10 @@ class BenchmarkConfig(object):
       raise ValueError('\'%s\' does not contain a Blaze command (e.g. build)' %
                        unit['command'])
     options = []
+    # Next, parse the options. We identify this by tokens that start with `--`.
+    # The exception is the token `--`, which is a valid syntax used to separate
+    # the flags from the targets: https://bazel.build/run/build#specifying-build-targets
+    # Example: bazel build --flag_a -- //foo -//exluded/...
     while full_command_tokens and full_command_tokens[0].startswith('--') and full_command_tokens[0] != '--':
       options.append(full_command_tokens.pop(0))
     # This is a workaround for https://github.com/bazelbuild/bazel/issues/3236.

--- a/utils/benchmark_config.py
+++ b/utils/benchmark_config.py
@@ -234,7 +234,7 @@ class BenchmarkConfig(object):
       raise ValueError('\'%s\' does not contain a Blaze command (e.g. build)' %
                        unit['command'])
     options = []
-    while full_command_tokens and full_command_tokens[0].startswith('--'):
+    while full_command_tokens and full_command_tokens[0].startswith('--') and full_command_tokens[0] != '--':
       options.append(full_command_tokens.pop(0))
     # This is a workaround for https://github.com/bazelbuild/bazel/issues/3236.
     if sys.platform.startswith('linux'):

--- a/utils/benchmark_config_test.py
+++ b/utils/benchmark_config_test.py
@@ -71,7 +71,7 @@ units:
    project_commit: 'hash2'
    env_configure: 'some-command'
  - bazel_path: /tmp/bazel
-   command: build --flag_a -- //foo -//excluded/..
+   command: build --flag_a -- //foo -//excluded/...
 """
     result = benchmark_config.BenchmarkConfig.from_string(file_content)
 
@@ -101,13 +101,13 @@ units:
         'bazel_path': '/tmp/bazel',
         'project_commit': 'hash3',
         'bazel_source': 'https://github.com/bazelbuild/bazel.git',
-        'env_configure': 'some-command',
+        'env_configure': None,
         'runs': 5,
         'collect_profile': False,
         'command': 'build',
         'startup_options': [],
         'options': _pad_test_command_options(['--flag_a']),
-        'targets': ['//foo']
+        'targets': ['--', '//foo', '-//excluded/...']
     }])
     self.assertEqual(result._benchmark_project_commits, False)
 

--- a/utils/benchmark_config_test.py
+++ b/utils/benchmark_config_test.py
@@ -70,6 +70,8 @@ units:
    command: build --nobuild //abc
    project_commit: 'hash2'
    env_configure: 'some-command'
+ - bazel_path: /tmp/bazel
+   command: build --flag_a -- //foo
 """
     result = benchmark_config.BenchmarkConfig.from_string(file_content)
 
@@ -95,6 +97,17 @@ units:
         'startup_options': [],
         'options': _pad_test_command_options(['--nobuild']),
         'targets': ['//abc']
+    }, {
+        'bazel_path': '/tmp/bazel',
+        'project_commit': 'hash3',
+        'bazel_source': 'https://github.com/bazelbuild/bazel.git',
+        'env_configure': 'some-command',
+        'runs': 5,
+        'collect_profile': False,
+        'command': 'build',
+        'startup_options': [],
+        'options': _pad_test_command_options(['--flag_a']),
+        'targets': ['//foo']
     }])
     self.assertEqual(result._benchmark_project_commits, False)
 

--- a/utils/benchmark_config_test.py
+++ b/utils/benchmark_config_test.py
@@ -71,7 +71,7 @@ units:
    project_commit: 'hash2'
    env_configure: 'some-command'
  - bazel_path: /tmp/bazel
-   command: build --flag_a -- //foo
+   command: build --flag_a -- //foo -//excluded/..
 """
     result = benchmark_config.BenchmarkConfig.from_string(file_content)
 


### PR DESCRIPTION
**What this PR does and why we need it:**

Support the bazel command's usage of `--` to separate the targets from the options.

Example:

```
bazel build --foo -- //target_bar -//exclude/...
```

