### PR TITLE
[Profile] Remove obsolete (non-existent) flags

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -197,8 +197,6 @@ def _construct_json_profile_flags(out_file_path):
   """
   return [
       '--experimental_generate_json_trace_profile',
-      '--experimental_profile_cpu_usage',
-      '--experimental_json_trace_compression',
       '--profile={}'.format(out_file_path)
   ]
 

--- a/benchmark_test.py
+++ b/benchmark_test.py
@@ -222,11 +222,11 @@ class BenchmarkFunctionTests(absltest.TestCase):
             'Executing Bazel command: bazel clean --color=no',
             'Executing Bazel command: bazel shutdown ',
             'Starting benchmark run 1/2:',
-            'Executing Bazel command: bazel build --experimental_generate_json_trace_profile --experimental_profile_cpu_usage --experimental_json_trace_compression --profile=fake_dir/fake_uid_fake_bazel_commit_0_fake_project_commit_1_of_2.profile.gz --nostamp --noshow_progress --color=no //:all',
+            'Executing Bazel command: bazel build --experimental_generate_json_trace_profile --profile=fake_dir/fake_uid_fake_bazel_commit_0_fake_project_commit_1_of_2.profile.gz --nostamp --noshow_progress --color=no //:all',
             'Executing Bazel command: bazel clean --color=no',
             'Executing Bazel command: bazel shutdown ',
             'Starting benchmark run 2/2:',
-            'Executing Bazel command: bazel build --experimental_generate_json_trace_profile --experimental_profile_cpu_usage --experimental_json_trace_compression --profile=fake_dir/fake_uid_fake_bazel_commit_0_fake_project_commit_2_of_2.profile.gz --nostamp --noshow_progress --color=no //:all',
+            'Executing Bazel command: bazel build --experimental_generate_json_trace_profile --profile=fake_dir/fake_uid_fake_bazel_commit_0_fake_project_commit_2_of_2.profile.gz --nostamp --noshow_progress --color=no //:all',
             'Executing Bazel command: bazel clean --color=no',
             'Executing Bazel command: bazel shutdown '
         ]), mock_stderr.getvalue())


### PR DESCRIPTION
### Changes
Removed couple of flags:
* experimental_profile_cpu_usage
* experimental_json_trace_compression

### Why
`experimental_profile_cpu_usage` is removed starting from Bazel 5.0 (and is always set to `true`). More [here](https://blog.bazel.build/2022/01/19/bazel-5.0.html#general).
`experimental_json_trace_compression` doesn't seem to exist anymore. Also according to [this](https://github.com/bazelbuild/bazel/issues/10171#issuecomment-550974706) comment is implicitly set to `true`. 