### PR TITLE
[Clean, Shutdown] Add flags to skip clean & shutdown

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -251,10 +251,10 @@ def _single_run(bazel_bin_path,
                   measurements['memory'],
                   measurements['exit_status']))
 
-  if not FLAGS.skip_clean:
+  if FLAGS.clean:
     bazel.command('clean', ['--color=no'])
 
-  if not FLAGS.skip_shutdown:
+  if FLAGS.shutdown:
     bazel.command('shutdown')
 
   return measurements
@@ -492,8 +492,8 @@ flags.DEFINE_string('platform', None,
                     ('The platform on which bazel-bench is run. This is just '
                      'to categorize data and has no impact on the actual '
                      'script execution.'))
-flags.DEFINE_boolean('skip_clean', False, 'Whether to invoke clean between runs/builds.')
-flags.DEFINE_boolean('skip_shutdown', False, 'Whether to invoke shutdown between runs/builds.')
+flags.DEFINE_boolean('clean', True, 'Whether to invoke clean between runs/builds.')
+flags.DEFINE_boolean('shutdown', True, 'Whether to invoke shutdown between runs/builds.')
 
 # Miscellaneous flags.
 flags.DEFINE_boolean('verbose', False,

--- a/benchmark.py
+++ b/benchmark.py
@@ -251,9 +251,12 @@ def _single_run(bazel_bin_path,
                   measurements['memory'],
                   measurements['exit_status']))
 
-  # Get back to a clean state.
-  bazel.command('clean', ['--color=no'])
-  bazel.command('shutdown')
+  if not FLAGS.skip_clean:
+    bazel.command('clean', ['--color=no'])
+
+  if not FLAGS.skip_shutdown:
+    bazel.command('shutdown')
+
   return measurements
 
 
@@ -489,6 +492,8 @@ flags.DEFINE_string('platform', None,
                     ('The platform on which bazel-bench is run. This is just '
                      'to categorize data and has no impact on the actual '
                      'script execution.'))
+flags.DEFINE_boolean('skip_clean', False, 'Whether to invoke clean between runs/builds.')
+flags.DEFINE_boolean('skip_shutdown', False, 'Whether to invoke shutdown between runs/builds.')
 
 # Miscellaneous flags.
 flags.DEFINE_boolean('verbose', False,

--- a/benchmark_test.py
+++ b/benchmark_test.py
@@ -259,6 +259,38 @@ class BenchmarkFlagsTest(absltest.TestCase):
         'Either --bazel_commits or --project_commits should be a single element.'
     )
 
+  @flagsaver.flagsaver(skip_clean=True)
+  def test_single_run_skip_clean(self):
+    with mock.patch.object(sys, 'stderr', new=mock_stdio_type()) as mock_stderr:
+      benchmark._single_run(
+          'bazel_binary_path',
+          'build',
+          options=[],
+          targets=['//:all'],
+          startup_options=[])
+
+    self.assertEqual(
+        ''.join([
+            'Executing Bazel command: bazel build --nostamp --noshow_progress --color=no //:all',
+            'Executing Bazel command: bazel shutdown '
+        ]), mock_stderr.getvalue())
+
+  @flagsaver.flagsaver(skip_shutdown=True)
+  def test_single_run_skip_clean(self):
+    with mock.patch.object(sys, 'stderr', new=mock_stdio_type()) as mock_stderr:
+      benchmark._single_run(
+          'bazel_binary_path',
+          'build',
+          options=[],
+          targets=['//:all'],
+          startup_options=[])
+
+    self.assertEqual(
+        ''.join([
+            'Executing Bazel command: bazel build --nostamp --noshow_progress --color=no //:all',
+            'Executing Bazel command: bazel clean --color=no'
+        ]), mock_stderr.getvalue())
+
 
 if __name__ == '__main__':
   absltest.main()

--- a/benchmark_test.py
+++ b/benchmark_test.py
@@ -259,7 +259,7 @@ class BenchmarkFlagsTest(absltest.TestCase):
         'Either --bazel_commits or --project_commits should be a single element.'
     )
 
-  @flagsaver.flagsaver(skip_clean=True)
+  @flagsaver.flagsaver(clean=False)
   def test_single_run_skip_clean(self):
     with mock.patch.object(sys, 'stderr', new=mock_stdio_type()) as mock_stderr:
       benchmark._single_run(
@@ -275,8 +275,8 @@ class BenchmarkFlagsTest(absltest.TestCase):
             'Executing Bazel command: bazel shutdown '
         ]), mock_stderr.getvalue())
 
-  @flagsaver.flagsaver(skip_shutdown=True)
-  def test_single_run_skip_clean(self):
+  @flagsaver.flagsaver(shutdown=False)
+  def test_single_run_skip_shutdown(self):
     with mock.patch.object(sys, 'stderr', new=mock_stdio_type()) as mock_stderr:
       benchmark._single_run(
           'bazel_binary_path',


### PR DESCRIPTION
**What this PR does and why we need it:**

Make `clean` and `shutdown` commands toggle-able. Right now, the benchmarking script cleans and shuts down the bazel process after each run. This is not always needed (especially when performing incremental benchmarks). 

* *New changes / Issues that this PR fixes:**

It doesn't entirely fix issue #[153](https://github.com/bazelbuild/bazel-bench/issues/153), but it addresses part of it. 
