### PR TITLE
Extend the `clean` and `shutdown` flags to BenchmarkConfig.py

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -594,7 +594,9 @@ def _get_benchmark_config_and_clone_repos(argv):
       env_configure=FLAGS.env_configure,
       runs=FLAGS.runs,
       collect_profile=FLAGS.collect_profile,
-      command=' '.join(bazel_args))
+      command=' '.join(bazel_args),
+      clean=FLAGS.clean,
+      shutdown=FLAGS.shutdown)
 
   return config, bazel_clone_repo, project_clone_repo
 

--- a/utils/benchmark_config.py
+++ b/utils/benchmark_config.py
@@ -31,6 +31,8 @@ benchmark_project_commits: False
 global_options:
   project_commit: 595a730
   runs: 5
+  clean: true
+  shutdown: true
   collect_profile: false
   project_source: /path/to/project/repo
 units:
@@ -64,6 +66,8 @@ class BenchmarkConfig(object):
       'collect_profile': False,
       'bazel_source': 'https://github.com/bazelbuild/bazel.git',
       'env_configure': None,
+      'clean': True,
+      'shutdown': True,
   }
 
   def __init__(self, units, benchmark_project_commits=False):
@@ -157,7 +161,7 @@ class BenchmarkConfig(object):
   @classmethod
   def from_flags(cls, bazel_commits, bazel_binaries, project_commits,
                  bazel_source, project_source, env_configure, runs,
-                 collect_profile, command):
+                 collect_profile, command, clean, shutdown):
     """Creates the BenchmarkConfig based on specified flags.
 
     Args:
@@ -173,6 +177,8 @@ class BenchmarkConfig(object):
       collect_profile: Whether to collect a JSON profile.
       command: the full command to benchmark, optionally with startup options
         prepended, e.g. "--noexobazel build --nobuild ...".
+      clean: Whether to invoke `bazel clean` between runs.
+      shutdown: Whether to invoke `bazel shutdown` between runs.
 
     Returns:
       The created config object.
@@ -190,6 +196,8 @@ class BenchmarkConfig(object):
                 'collect_profile': collect_profile,
                 'env_configure': env_configure,
                 'command': command,
+                'clean': clean,
+                'shutdown': shutdown,
             }))
     for bazel_binary in bazel_binaries:
       for project_commit in project_commits:
@@ -203,6 +211,8 @@ class BenchmarkConfig(object):
                 'collect_profile': collect_profile,
                 'env_configure': env_configure,
                 'command': command,
+                'clean': clean,
+                'shutdown': shutdown,
             }))
     return cls(units, benchmark_project_commits=(len(project_commits) > 1))
 

--- a/utils/benchmark_config_test.py
+++ b/utils/benchmark_config_test.py
@@ -52,6 +52,8 @@ units:
         'options': _pad_test_command_options([]),
         'targets': [],
         'env_configure': None,
+        'clean': True,
+        'shutdown': True,
     }])
     self.assertEqual(result._benchmark_project_commits, False)
     os.remove(config_file_path)
@@ -85,7 +87,9 @@ units:
         'command': 'info',
         'startup_options': [],
         'options': _pad_test_command_options([]),
-        'targets': []
+        'targets': [],
+        'clean': True,
+        'shutdown': True
     }, {
         'bazel_path': '/tmp/bazel',
         'project_commit': 'hash2',
@@ -96,7 +100,9 @@ units:
         'command': 'build',
         'startup_options': [],
         'options': _pad_test_command_options(['--nobuild']),
-        'targets': ['//abc']
+        'targets': ['//abc'],
+        'clean': True,
+        'shutdown': True
     }, {
         'bazel_path': '/tmp/bazel',
         'project_commit': 'hash3',
@@ -107,7 +113,9 @@ units:
         'command': 'build',
         'startup_options': [],
         'options': _pad_test_command_options(['--flag_a']),
-        'targets': ['--', '//foo', '-//excluded/...']
+        'targets': ['--', '//foo', '-//excluded/...'],
+        'clean': True,
+        'shutdown': True
     }])
     self.assertEqual(result._benchmark_project_commits, False)
 
@@ -122,7 +130,10 @@ units:
         runs=5,
         env_configure='some-command',
         collect_profile=False,
-        command='build --nobuild //abc')
+        command='build --nobuild //abc',
+        clean=False,
+        shutdown=False,
+    )
     self.assertEqual(result._units, [{
         'bazel_commit': 'hash1',
         'project_commit': 'hash3',
@@ -134,7 +145,9 @@ units:
         'command': 'build',
         'startup_options': [],
         'options': _pad_test_command_options(['--nobuild']),
-        'targets': ['//abc']
+        'targets': ['//abc'],
+        'clean': False,
+        'shutdown': False,
     }, {
         'bazel_binary': 'path/to/bazel',
         'project_commit': 'hash3',
@@ -146,7 +159,9 @@ units:
         'command': 'build',
         'startup_options': [],
         'options': _pad_test_command_options(['--nobuild']),
-        'targets': ['//abc']
+        'targets': ['//abc'],
+        'clean': False,
+        'shutdown': False,
     }])
     self.assertEqual(result._benchmark_project_commits, False)
 


### PR DESCRIPTION
**What this PR does and why we need it:**

Extension to https://github.com/bazelbuild/bazel-bench/pull/164. This allows to specify `clean` and `shutdown` flags in the config (yaml) file.
