### PR TITLE
Disable bzlmod to make the tests green again.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,1 @@
+build --noenable_bzlmod


### PR DESCRIPTION
We should properly opt in to bzlmod to fix https://github.com/bazelbuild/bazel-bench/issues/168
