### PR TITLE
Update .bazelrc

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,1 +1,2 @@
 build --noenable_bzlmod
+build --incompatible_disallow_empty_glob


### PR DESCRIPTION
Make sure that no regressions are introduced to build with incompatible_disallow_empty_glob

**What this PR does and why we need it:**

It makes sure that this repository can be built with incompatible_disallow_empty_glob and it works in the moment that incompatible_disallow_empty_glob is enabled by default

**New changes / Issues that this PR fixes:**

It contributes to https://github.com/bazelbuild/bazel/pull/15327

**Special notes for reviewer:**

See https://github.com/bazelbuild/bazel/pull/15327 for more details

**Does this require a change in the script's interface or the BigQuery's table structure?**

I expect no